### PR TITLE
Handle OAuth errors gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const BaseDevice = require('./lib/base_device');
 const Helpers = require('./lib/helpers');
 const ObjectSet = require('./lib/object_set');
 const ConfigDelegate = require('./lib/config_delegate');
+const { OAuthError } = require('./lib/errors');
 
 const ThingTalk = require('thingtalk');
 
@@ -59,6 +60,8 @@ module.exports = {
         Location: ThingTalk.Builtin.Location,
         Time: ThingTalk.Builtin.Time
     },
+
+    OAuthError,
 
     version: VERSION
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,16 @@
+//
+// This file is part of ThingEngine
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+class OAuthError extends Error {
+}
+
+module.exports = {
+    OAuthError
+};

--- a/lib/helpers/oauth2.js
+++ b/lib/helpers/oauth2.js
@@ -11,6 +11,8 @@
 const crypto = require('crypto');
 const oauth = require('oauth');
 
+const { OAuthError } = require('../errors');
+
 // encryption ;)
 function rot13(x) {
     return Array.prototype.map.call(x, (ch) => {
@@ -28,10 +30,10 @@ module.exports = function OAuth2Helper(params) {
     function runOAuth2(engine, req) {
         const factory = this;
         if (!factory.metadata.auth.client_id && !params.client_id)
-            throw new Error('Missing OAuth Client ID in Authentication part of the manifest');
+            throw new OAuthError('Missing OAuth Client ID in Authentication part of the manifest');
         const client_id = factory.metadata.auth.client_id || params.client_id;
         if (!factory.metadata.auth.client_secret && !params.client_secret)
-            throw new Error('Missing OAuth Client Secret in Authentication part of the manifest');
+            throw new OAuthError('Missing OAuth Client Secret in Authentication part of the manifest');
         const client_secret = factory.metadata.auth.client_secret || rot13(params.client_secret);
 
         const customHeaders = params.custom_headers || {};
@@ -99,9 +101,7 @@ module.exports = function OAuth2Helper(params) {
                     else
                         msg = String(req.query.error);
 
-                    // FIXME make this string translatable
-                    msg = `There is a problem with the Thingpedia account or device you are trying to configure: ${msg}. Please report this issue to the developer of Thingpedia device.`;
-                    return Promise.reject(new Error(msg));
+                    return Promise.reject(new OAuthError(msg));
                 }
             }
 
@@ -111,7 +111,7 @@ module.exports = function OAuth2Helper(params) {
             // we are more lenient, and allow state to be unset on errors
             const state = req.query.state;
             if (params.set_state && state !== expectedState)
-                return Promise.reject(new Error("Invalid CSRF token"));
+                return Promise.reject(new OAuthError("Invalid CSRF token"));
 
             const options = {
                 grant_type: 'authorization_code',
@@ -129,9 +129,9 @@ module.exports = function OAuth2Helper(params) {
             }).catch((e) => {
                 console.error('Error obtaining access token', e);
                 if (!e.message)
-                    throw new Error('Error obtaining access token');
+                    throw new OAuthError('Error obtaining access token');
                 else
-                    throw e;
+                    throw new OAuthError(e.message);
             });
         }
     }
@@ -172,9 +172,9 @@ module.exports = function OAuth2Helper(params) {
                 }).catch((e) => {
                     console.error('Error obtaining access token', e);
                     if (!e.message)
-                        throw new Error('Error obtaining access token');
+                        throw new OAuthError('Error obtaining access token');
                     else
-                        throw e;
+                        throw new OAuthError(e.message);
                 });
             },
             configurable: true,

--- a/lib/helpers/oauth2.js
+++ b/lib/helpers/oauth2.js
@@ -73,12 +73,45 @@ module.exports = function OAuth2Helper(params) {
             return [auth.getAuthorizeUrl(query), session];
         } else {
             // step 2
-            const code = req.query.code;
-            const state = req.query.state;
-            if (params.set_state &&
-                state !== req.session['oauth2-state-' + factory.metadata.kind])
-                return Promise.reject(new Error("Invalid CSRF token"));
+
+            const expectedState = req.session['oauth2-state-' + factory.metadata.kind];
             delete req.session['oauth2-state-' + factory.metadata.kind];
+
+            // according to RFC 6749, if the user cancels, or some error
+            // occurs, the browser is redirected to the configured redirect URL,
+            // but with the `error` query parameter set to an error code
+            // (https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
+            //
+            // Of the error codes defined, `access_denied` can be triggered
+            // legitimately if the user cancels / changes their mind, while
+            // the others are all programming or configuration errors
+            if (req.query.error) {
+                if (req.query.error === 'access_denied') {
+                    // if the user cancels, do nothing, successfully
+                    return null;
+                } else {
+                    // fail with an error - the error is in Thingpedia, not
+                    // in the client
+
+                    let msg;
+                    if (req.query.error_description)
+                        msg = String(req.query.error_description);
+                    else
+                        msg = String(req.query.error);
+
+                    // FIXME make this string translatable
+                    msg = `There is a problem with the Thingpedia account or device you are trying to configure: ${msg}. Please report this issue to the developer of Thingpedia device.`;
+                    return Promise.reject(new Error(msg));
+                }
+            }
+
+            const code = req.query.code;
+
+            // NOTE: according to RFC 6749, `state` should be set on errors too
+            // we are more lenient, and allow state to be unset on errors
+            const state = req.query.state;
+            if (params.set_state && state !== expectedState)
+                return Promise.reject(new Error("Invalid CSRF token"));
 
             const options = {
                 grant_type: 'authorization_code',


### PR DESCRIPTION
Recognize them, and handle them correctly, in particular when the error is just the user cancelling the configuration of a device.