### PR TITLE
compat: expose "version" in device.constructor.metadata

### DIFF
--- a/lib/compat.js
+++ b/lib/compat.js
@@ -105,6 +105,7 @@ function makeBaseDeviceMetadata(classDef) {
     const [auth, extraTypes] = getAuth(classDef);
     return {
         kind: classDef.kind,
+        version: classDef.annotations.version.toJS(),
         name: classDef.metadata.name,
         description: classDef.metadata.description,
         types: (classDef.extends || []).concat(extraTypes),


### PR DESCRIPTION
thingengine-core, almond-gnome & almond-android use this field
to report the version of each device

Should fix https://github.com/stanford-oval/almond-gnome/issues/46