### PR TITLE
Handle abstract classes correctly when referenced as subdevices

### DIFF
--- a/lib/compat.js
+++ b/lib/compat.js
@@ -12,6 +12,9 @@
 
 function getParams(classDef) {
     let params = {};
+    if (classDef.is_abstract)
+        return params;
+
     const config = classDef.config;
     switch (config.module) {
     case 'org.thingpedia.config.form':
@@ -30,6 +33,9 @@ function getParams(classDef) {
 function getAuth(classDef) {
     let auth = {};
     let extraTypes = [];
+
+    if (classDef.is_abstract)
+        return [auth, extraTypes];
 
     const config = classDef.config;
     config.in_params.forEach((param) => {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -17,6 +17,9 @@ module.exports = {
     'org.thingpedia.config.*': require('./base'),
 
     get(classdef) {
+        if (classdef.is_abstract)
+            return null;
+
         const config = classdef.config;
         const mixinclass = this[config.module] || this['org.thingpedia.config.*'];
         return new mixinclass(classdef);

--- a/lib/loaders/base_generic.js
+++ b/lib/loaders/base_generic.js
@@ -48,7 +48,8 @@ module.exports = class BaseGenericModule {
                 return BaseDevice.Availability.AVAILABLE;
             }
         };
-        this._config.install(this._loaded);
+        if (this._config)
+            this._config.install(this._loaded);
 
         this._loaded.metadata = makeBaseDeviceMetadata(this._manifest);
     }

--- a/lib/loaders/base_js.js
+++ b/lib/loaders/base_js.js
@@ -113,7 +113,8 @@ module.exports = class BaseJavascriptModule {
     }
 
     async _completeLoading(deviceClass) {
-        this._config.install(deviceClass);
+        if (this._config)
+            this._config.install(deviceClass);
         deviceClass.metadata = makeBaseDeviceMetadata(this._manifest);
 
         for (let action in this._manifest.actions) {


### PR DESCRIPTION
This way, the subdevices field of the class need not use a concrete device,
and we avoid creating a lot of concrete devices for gateway-managed
stuff.