### PR TITLE
Document the Thingpedia SDK with jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,22 +26,59 @@ const BasePlatform = require('./lib/base_platform');
 
 const ThingTalk = require('thingtalk');
 
+/**
+ * Versioning information for the library.
+ *
+ * Use this object to check if the currently loaded Thingpedia SDK
+ * is compatible with your device, and to dynamically check if a specific
+ * feature is present.
+ *
+ * Note: you should never bundle the Thingpedia SDK with your device.
+ *
+ * @alias version
+ * @namespace
+ */
 const VERSION = {
+    /** Major version number (incremented on incompatible changes) */
     major: 2,
+    /** Minor version number (incremented on feature additions) */
     minor: 6,
+    /** Full version string, in semantic version format */
     full: '2.6.0-alpha.1',
+    /** Convert the version number to a number (for comparisons) */
     valueOf() {
         return this.major * 100 + this.minor;
     },
     toString() {
         return this.full;
     },
+    /**
+     * Check if the current version is compatible with the passed in version
+     *
+     * @param {number|Version} v - the version, as a number or object with `major`
+     *                             and minor properties
+     * @return {Boolean}
+     */
     compatible(v) {
         if (typeof v === 'number')
             return this.valueOf() >= v && Math.floor(v/100) === this.major;
         else
             return this.major === v.major && this.minor >= v.minor;
     },
+    /**
+     * Check if the given feature is present.
+     *
+     * It is ok to pass invalid or unrecognized feature names to this function,
+     * which will then return `false`.
+     *
+     * In this version of the library, the following feature names are recognized:
+     * - `rss`: RSS helpers and loaders
+     * - `value-types`: ThingTalk value types are re-exported
+     * - `thingpedia-client`: Thingpedia Client APIs are present
+     *
+     * @param {String} f - a feature name
+     * @return {Boolean} whether the named feature is supported.
+     */
     hasFeature(f) {
         switch (f) {
         case 'rss':

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,20 @@
+{
+    "plugins": [
+        "plugins/markdown"
+    ],
+    "recurseDepth": 10,
+    "source": {
+        "includePattern": ".+\\.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "sourceType": "module",
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "templates": {
+        "cleverLinks": true,
+        "monospaceLinks": true
+    }
+}
+

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -14,7 +14,10 @@
     },
     "templates": {
         "cleverLinks": true,
-        "monospaceLinks": true
+        "monospaceLinks": true,
+        "default": {
+          "useLongnameInNav": true
+        }
     }
 }
 

--- a/lib/base_client.js
+++ b/lib/base_client.js
@@ -11,10 +11,25 @@
 
 const Mixins = require('./mixins.json');
 
-module.exports = class ThingpediaClientBase {
+/**
+ * The base class of all clients to access the Thingpedia API.
+ *
+ * Accessing the Thingpedia API from Almond occurs in a platform-specific manner,
+ * through clients that extend this class.
+ */
+class BaseClient {
+    /**
+     * @protected
+     */
     constructor() {
     }
 
+    /**
+     * The locale to use when querying Thingpedia, as BCP 47 tag.
+     *
+     * @type {string}
+     * @readonly
+     */
     get locale() {
         throw new Error('not implemented');
     }
@@ -100,4 +115,5 @@ module.exports = class ThingpediaClientBase {
             mixins[mixin.kind] = mixin;
         return Promise.resolve(mixins);
     }
-};
+}
+module.exports = BaseClient;

--- a/lib/base_client.js
+++ b/lib/base_client.js
@@ -16,6 +16,8 @@ const Mixins = require('./mixins.json');
  *
  * Accessing the Thingpedia API from Almond occurs in a platform-specific manner,
  * through clients that extend this class.
+ *
+ * @interface
  */
 class BaseClient {
     /**

--- a/lib/base_device.js
+++ b/lib/base_device.js
@@ -55,22 +55,38 @@ class BaseDevice extends events.EventEmitter {
      *
      * @param {BaseEngine} engine - the shared Almond engine initializing this device
      * @param {Object} state - arbitrary JSON data associated with this device
+     * @protected
      */
     constructor(engine, state) {
         super();
         this._engine = engine;
-        this.state = state;
 
-        // Set this to a device specific ID plus something unique
-        // (eg "mydevice-aa-bb-cc-dd-ee-ff") so that no other device
-        // can possibly have the same ID
-        // If you leave it unset, DeviceDatabase will pick for you
+        /**
+         * The current device state.
+         *
+         * @readonly
+         * @type {Object}
+         */
+        this.state = state;
 
         // provide default uniqueId for config.none() devices
         const ast = this.metadata;
         const params = Object.keys(ast.params);
         const isNoneFactory = ast.auth.type === 'none' && params.length === 0;
         const isNoneAuth = ast.auth.type === 'none';
+
+        /**
+         * The unique ID of this device instance.
+         *
+         * Device implementations should set this the Thingpedia kind (class ID) plus something unique
+         * (eg "com.mydevice/aa-bb-cc-dd-ee-ff") so that no other device
+         * can possibly have the same ID.
+         * If you leave it unset, a unique identifier will be automatically generated.
+         *
+         * @name BaseDevice#uniqueId
+         * @type {string}
+         * @member
+         */
         if (isNoneFactory)
             this.uniqueId = this.kind;
         else if (isNoneAuth)
@@ -81,17 +97,49 @@ class BaseDevice extends events.EventEmitter {
         // provide default name and description
         // NOTE: these are not getters, because the subclass can override
         // them and mutate them as it wishes
+
+        /**
+         * The user-visible name of this device instance.
+         *
+         * If multiple instances of the same class can reasonably be configured by the same
+         * user (e.g. multiple devices of the same brand, or multiple accounts on the same service),
+         * they should have different names.
+         * This defaults to the name provided in Thingpedia.
+         *
+         * @type {string}
+         */
         this.name = ast.name;
+        /**
+         * A longer description of this device instance.
+         *
+         * This can be used to add additional distinguishing information, such as the URL
+         * or address of a local gateway.
+         * It defaults to the description provided in Thingpedia.
+         *
+         * @type {string}
+         */
         this.description = ast.description;
 
-        // Set these to protocol/discovery specific IDs (such as
-        // "bluetooth/aa-bb-cc-dd-ee-ff") so that it is unlikely that
-        // another device has the same ID
+        /**
+         * Discovery protocol descriptors.
+         *
+         * Device implementations should set these to protocol/discovery specific IDs (such as
+         * "bluetooth/aa-bb-cc-dd-ee-ff") so that it is unlikely that
+         * another device has the same ID.
+         *
+         * @type {string[]}
+         */
         this.descriptors = [];
 
-        // Set to true if this device should not be stored in the devicedb
-        // but only kept in memory (ie, its lifetime is managed by some
-        // device discovery module, or it's a subdevice of some other device)
+        /**
+         * Indicates a transient device.
+         *
+         * Set to true if this device should not be stored in the device database
+         * but only kept in memory (i.e., its lifetime is managed by some
+         * device discovery module, or it's a subdevice of some other device).
+         *
+         * @type {boolean}
+         */
         this.isTransient = false;
 
         this._ownerTier = undefined;
@@ -256,6 +304,9 @@ class BaseDevice extends events.EventEmitter {
 
     /**
      * The Thingpedia "kind" (unique class ID) of this device.
+     *
+     * @type string
+     * @readonly
      */
     get kind() {
         return this.state.kind;
@@ -269,7 +320,8 @@ class BaseDevice extends events.EventEmitter {
     /**
      * Access the current platform for this device instance.
      *
-     * @return {BasePlatform}
+     * @type {BasePlatform}
+     * @readonly
      */
     get platform() {
         return this._engine.platform;
@@ -278,7 +330,8 @@ class BaseDevice extends events.EventEmitter {
     /**
      * Access the current engine for this device instance.
      *
-     * @return {BaseEngine}
+     * @type {BaseEngine}
+     * @readonly
      * @deprecated It is recommended to avoid using the {@link BaseEngine} API as it can change without notice.
      */
     get engine() {
@@ -293,6 +346,7 @@ class BaseDevice extends events.EventEmitter {
      * persisted on disk.
      *
      * @fires BaseDevice#state-changed
+     * @protected
      */
     stateChanged() {
         /**

--- a/lib/base_device.js
+++ b/lib/base_device.js
@@ -12,6 +12,14 @@
 const events = require('events');
 const Url = require('url');
 
+/**
+ * The coarse grain classification of the currently running Almond platform.
+ *
+ * Tiers are used to inform how synchronization of device database occurs.
+ *
+ * @alias BaseDevice.Tier
+ * @enum {string}
+ */
 const Tier = {
     GLOBAL: 'global',
     PHONE: 'phone',
@@ -20,6 +28,12 @@ const Tier = {
     CLOUD: 'cloud'
 };
 
+/**
+ * Whether a device is available (power on and accessible).
+ *
+ * @alias BaseDevice.Availability
+ * @enum {number}
+ */
 const Availability = {
     UNAVAILABLE: 0,
     AVAILABLE: 1,
@@ -27,7 +41,21 @@ const Availability = {
     UNKNOWN: -1
 };
 
-module.exports = class BaseDevice extends events.EventEmitter {
+/**
+ * The base class of all Thingpedia device implementations.
+ *
+ * @extends events.EventEmitter
+ */
+class BaseDevice extends events.EventEmitter {
+    /**
+     * Construct a new Thingpedia device.
+     *
+     * You should never construct a BaseDevice directly. Only subclasses should
+     * call the constructor.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @param {Object} state - arbitrary JSON data associated with this device
+     */
     constructor(engine, state) {
         super();
         this._engine = engine;
@@ -72,17 +100,21 @@ module.exports = class BaseDevice extends events.EventEmitter {
     // configuration interfaces
 
     /**
-      Begin configuring this device using a custom OAuth-like flow.
-
-      This includes OAuth 1.0 and OAuth 2.0 with custom code.
-      Standard uses of OAuth 2.0 should not override this method. Instead, they
-      should use the @org.thingpedia.config.oauth2() mixin, and override loadFromOAuth2.
-
-      The method should return a tuple of:
-      - redirect uri (a String)
-      - session object (a plain JS object mapping String to String)
-
-      The data in the session object will be passed to `completeCustomOAuth`.
+     * Begin configuring this device using a custom OAuth-like flow.
+     *
+     * This includes OAuth 1.0 and OAuth 2.0 with custom code.
+     * Standard uses of OAuth 2.0 should not override this method. Instead, they
+     * should use the `@org.thingpedia.config.oauth2()` mixin, and override {@link BaseDevice.loadFromOAuth2}.
+     *
+     * The method should return a tuple of:
+     * - redirect uri (a String)
+     * - session object (a plain JS object mapping String to String)
+     *
+     * The data in the session object will be passed to `completeCustomOAuth`.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @return {Array} tuple of redirect URI and session data
+     * @abstract
     */
     static async loadFromCustomOAuth(engine) {
         // if not overridden, call the compatibility method using the legacy interface
@@ -92,13 +124,17 @@ module.exports = class BaseDevice extends events.EventEmitter {
     }
 
     /**
-      Complete configuring this device using custom OAuth-like flows.
-
-      This method will be called after the user redirects back to Almond,
-      and will be passed the redirect URL, and the session information that was returned
-      by loadFromCustomOAuth.
-
-      This method should return a new device instance.
+     * Complete configuring this device using custom OAuth-like flows.
+     *
+     * This method will be called after the user redirects back to Almond,
+     * and will be passed the redirect URL, and the session information that was returned
+     * by {@link BaseDevice.loadFromCustomOAuth}.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @param {string} url - the redirect URL called after completing OAuth
+     * @param {Object.<string,string>} session - session data that was returned from {@link BaseDevice.loadFromCustomOAuth}
+     * @return {BaseDevice} the fully configured device instance
+     * @abstract
     */
     static async completeCustomOAuth(engine, url, session) {
         // if not overridden, call the compatibility method with a made-up `req` object
@@ -114,53 +150,83 @@ module.exports = class BaseDevice extends events.EventEmitter {
         return this.runOAuth2(engine, req);
     }
 
-    /**
-      Configure this device using OAuth 2.0
-
-      This method is called by the OAuth 2.0 helpers (@org.thingpedia.config.oauth2())
-      and should return a new device instance.
-    */
     /* istanbul ignore next */
+    /**
+     * Configure this device using OAuth 2.0
+     *
+     * This method is called by the OAuth 2.0 helpers (`@org.thingpedia.config.oauth2()`)
+     * and should return a new device instance.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @param {string} accessToken - the OAuth access token
+     * @param {string} [refreshToken] - the OAuth refresh token, if one is provided
+     * @param {Object} extraData - the whole response to the OAuth token request
+     * @abstract
+    */
     static async loadFromOAuth2(engine, accessToken, refreshToken, extraData) {
         throw new Error('not implemented');
     }
 
-    /**
-      Configure this device using local discovery.
-
-      The method should return a new device instance. The instance might be partially
-      initialized (e.g. for Bluetooth, the device might not be paired). If the user
-      chooses to continue configuring the device, `completeDiscovery()` will be called.
-    */
     /* istanbul ignore next */
+    /**
+     * Configure this device using local discovery.
+     *
+     * The method should return a new device instance. The instance might be partially
+     * initialized (e.g. for Bluetooth, the device might not be paired). If the user
+     * chooses to continue configuring the device, {@link BaseDevice#completeDiscovery} will be called.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @param {Object} publicData - protocol specific data that is public (e.g. Bluetooth UUIDs)
+     * @param {Object} privateData - protocol specific data that is specific to the device and
+     *                               private to the user (e.g. Bluetooth HW address)
+     * @return {BaseDevice} the new, partially initialized device instance
+     * @abstract
+    */
     static async loadFromDiscovery(engine, publicData, privateData) {
         throw new Error('not implemented');
     }
 
-    /**
-      Complete configuring this device from local discovery.
-
-      Note this is an instance method, not a static method. It will be called
-      on the partially initialized instance returned by `loadFromDiscovery()`.
-
-      The method should return the device instance itself ("this").
-    */
     /* istanbul ignore next */
+    /**
+     * Complete configuring this device from local discovery.
+     *
+     * The implementation should use the passed delegate to interact with the user, for
+     * example to have the user enter or confirm a PIN code shown on the device, or have
+     * the user press a physical button on the device.
+     *
+     * Note this is an instance method, not a static method. It will be called
+     * on the partially initialized instance returned by {@link BaseDevice.loadFromDiscovery}.
+     *
+     *
+     * @param {ConfigDelegate} delegate - a delegate object to interact with the user and complete configuration
+     * @return {BaseDevice} the device instance itself (`this`)
+     * @abstract
+    */
     async completeDiscovery(delegate) {
         throw new Error('not implemented');
     }
 
-    /**
-      Update the device state based on local discovery data.
-    */
     /* istanbul ignore next */
+    /**
+     * Update the device state based on local discovery data.
+     *
+     * @param {Object} privateData - protocol specific data that is specific to the device and
+     *                               private to the user (e.g. Bluetooth HW address)
+     */
     async updateFromDiscovery(privateData) {
         // nothing to do here, subclasses can override if they support discovery
     }
 
     /**
-      Update the device state when the OAuth 2.0 token is refreshed.
-    */
+     * Update the device state when the OAuth 2.0 token is refreshed.
+     *
+     * The default implementation will store the new access token and refresh token,
+     * and ignore other fields.
+     *
+     * @param {string} accessToken - the new access token
+     * @param {string} [refreshToken] - the new refresh token, if one is provided
+     * @param {Object} extraData - the whole response to the OAuth token request
+     */
     async updateOAuth2Token(accessToken, refreshToken, extraData) {
         this.state.accessToken = accessToken;
         // if the refresh token is single use, we will get a new one when we use it
@@ -170,34 +236,81 @@ module.exports = class BaseDevice extends events.EventEmitter {
         this.stateChanged();
     }
 
-    /**
-      Configure this device using interactive (voice-based) configuration.
-    */
     /* istanbul ignore next */
+    /**
+     * Configure this device using interactive (voice-based) configuration.
+     *
+     * The implementation should use the passed delegate to interact with the user, for
+     * example to have the user enter a password or answer a question.
+     *
+     * @param {BaseEngine} engine - the shared Almond engine initializing this device
+     * @param {ConfigDelegate} delegate - a delegate object to interact with the user and complete configuration
+     * @return {BaseDevice} the fully configured device instance
+     * @abstract
+     */
     static async loadInteractively(engine, delegate) {
         // if not overridden, call the compatibility method
         // NOTE: we're in a static method, so "this" refers to the class, not the instance!
         return this.configureFromAlmond(engine, delegate);
     }
 
+    /**
+     * The Thingpedia "kind" (unique class ID) of this device.
+     */
     get kind() {
         return this.state.kind;
     }
+
+    // obsolete, do not use
     get metadata() {
         return this.constructor.metadata;
     }
+
+    /**
+     * Access the current platform for this device instance.
+     *
+     * @return {BasePlatform}
+     */
     get platform() {
         return this._engine.platform;
     }
+
+    /**
+     * Access the current engine for this device instance.
+     *
+     * @return {BaseEngine}
+     * @deprecated It is recommended to avoid using the {@link BaseEngine} API as it can change without notice.
+     */
     get engine() {
         console.log('BaseDevice.engine is deprecated and should not be used in new code.');
         return this._engine;
     }
 
+    /**
+     * Notify that the device's serialized state changed.
+     *
+     * This should be called after any change to {@link BaseDevice#state} meant to be
+     * persisted on disk.
+     *
+     * @fires BaseDevice#state-changed
+     */
     stateChanged() {
+        /**
+         * Reports a change in device state.
+         *
+         * @event BaseDevice#state-changed
+         */
         this.emit('state-changed');
     }
 
+    /**
+     * Replace the current serialized state of the device.
+     *
+     * This method is called by Almond as part of the device synchronization logic.
+     * It can also be called by device implementations if the state changes outside of the class.
+     *
+     * @param {Object} state - the new state
+     */
     updateState(state) {
         // nothing to do here by default, except for updating the state
         // pointer
@@ -205,6 +318,11 @@ module.exports = class BaseDevice extends events.EventEmitter {
         this.state = state;
     }
 
+    /**
+     * Serialize the device to disk
+     *
+     * @return {Object} the serialized device representation
+     */
     serialize() {
         if (!this.state)
             throw new Error('Device lost state, cannot serialize');
@@ -212,12 +330,24 @@ module.exports = class BaseDevice extends events.EventEmitter {
     }
 
     /* istanbul ignore next */
-    start() {
+    /**
+     * Start a device.
+     *
+     * This method will be called when the device is loaded (after configuration
+     * or when the engine is restarted).
+     */
+    async start() {
         // nothing to do here, subclasses can override if they need to
     }
 
     /* istanbul ignore next */
-    stop() {
+    /**
+     * Stop a device.
+     *
+     * This method will be called when the device is unloaded, either because the
+     * user removed it or because the engine is terminating.
+     */
+    async stop() {
         // nothing to do here, subclasses can override if they need to
     }
 
@@ -227,20 +357,28 @@ module.exports = class BaseDevice extends events.EventEmitter {
         return Tier.GLOBAL;
     }
 
-    // Perform an async check to verify if the device is available
-    // (ie, on, working, reachable on the local network, etc.)
-    // Returns a promise of the device availability
-    checkAvailable() {
+    /**
+     * Perform an async check to verify if the device is available
+     * (i.e., on, working, reachable on the local network, etc.)
+     *
+     * @returns {BaseDevice.Availability} whether the device is available or not.
+     */
+    async checkAvailable() {
         return Availability.UNKNOWN;
     }
 
-    // Check if this device corresponds to the abstract kind (type) "kind",
-    // ie, it's a bluetooth device, or a phone, or remote device,
-    // or has an accelerometer, or whatever...
-    // A device can have multiple kinds at the same time
-    //
-    // Do not override this function. Instead, add more types to
-    // the Thingpedia metadata.
+    /**
+     * Check if this device implements the given Thingpedia kind.
+     *
+     * A device can have multiple kinds at the same time.
+     *
+     * You should not override this function. Instead, you should mark your
+     * ThingTalk class as extending another ThingTalk class.
+     * If you do override it, you must chain up to handle the default kinds.
+     *
+     * @param {string} kind - the Thingpedia kind to check
+     * @return {boolean} whether the device implements this interface or not
+     */
     hasKind(kind) {
         if (kind === 'data-source')
             return this.constructor.metadata.category === 'data';
@@ -253,32 +391,38 @@ module.exports = class BaseDevice extends events.EventEmitter {
             (this.constructor.metadata.types.indexOf(kind) >= 0);
     }
 
-    // Request an extension interface for this device
-    // Extension interfaces allow to provide additional device and
-    // vendor specific capabilities without the use of channels
-    // If the interface is not recognized this method returns null
-    // (up to the caller to check it or just use it blindly and explode)
-    //
-    // Note that all method calls on the interface might fail if
-    // the device is not available (but are not required to)
-    // Also note that this method might return null if the device
-    // exists but not locally (eg, it's a bluetooth device but we're
-    // running on the server platform)
-    //
-    // Well-known extension interfaces are "subdevices" (for device
-    // collections) and "messaging" (for the messaging system)
     /* istanbul ignore next */
-    queryInterface() {
+    /**
+     * Request an extension interface for this device.
+     *
+     * Extension interfaces allow to provide additional device and
+     * vendor specific capabilities that do not map to ThingTalk functions.
+     * If the interface is not recognized this method returns null
+     * (up to the caller to check it or just use it blindly and explode).
+     *
+     * Note that all method calls on the interface might fail if
+     * the device is not available (but are not required to).
+     * Also note that this method might return null if the device
+     * exists but not locally (e.g., it's a bluetooth device but we're
+     * running on a cloud platform).
+     *
+     * Well-known extension interfaces are "subdevices" (for device
+     * collections) and "messaging" (for the messaging system)
+     *
+     * @param {string} name - the interface name
+     * @return {any} the extension implementation
+     */
+    queryInterface(name) {
         // no extension interfaces for this device class
         return null;
     }
-};
-
+}
 // no $rpc for queryInterface, extension interfaces are not exported
-module.exports.prototype.$rpcMethods = [
+BaseDevice.prototype.$rpcMethods = [
     'get name', 'get uniqueId', 'get description',
     'get ownerTier', 'get kind', 'get isTransient',
     'checkAvailable', 'hasKind'];
 
+module.exports = BaseDevice;
 module.exports.Availability = Availability;
 module.exports.Tier = Tier;

--- a/lib/base_engine.js
+++ b/lib/base_engine.js
@@ -13,7 +13,22 @@ const ThingTalk = require('thingtalk');
 
 const ThingpediaHttpClient = require('./http_client');
 
-module.exports = class BaseEngine {
+/**
+ * The base Almond engine class.
+ *
+ * This contains the only API that should be considered stable in the Engine.
+ * All other APIs are a private implementation detail.
+ */
+class BaseEngine {
+    /**
+     * Construct an engine instance.
+     *
+     * @param {BasePlatform} platform - the platform associated with this engine
+     * @param {Object} options - additional options
+     * @param {string} [options.thingpediaUrl] - the Thingpedia URL to use (if the platform
+     *                                           does not provide a {@link BaseClient})
+     * @protected
+     */
     constructor(platform, options = {}) {
         this._platform = platform;
 
@@ -25,16 +40,46 @@ module.exports = class BaseEngine {
         this._schemas = new ThingTalk.SchemaRetriever(this._thingpedia);
     }
 
+    /**
+     * The current tier of the engine.
+     *
+     * See {@link BaseDevice.Tier} for an explanation.
+     *
+     * @type {BaseDevice.Tier}
+     * @readonly
+     */
     get ownTier() {
         return 'desktop';
     }
+
+    /**
+     * The platform associated with the engine.
+     *
+     * @type {BasePlatform}
+     * @readonly
+     */
     get platform() {
         return this._platform;
     }
+
+    /**
+     * The Thingpedia Client associated with the engine.
+     *
+     * @type {BaseClient}
+     * @readonly
+     */
     get thingpedia() {
         return this._thingpedia;
     }
+
+    /**
+     * The ThingTalk SchemaRetriever associated with the engine.
+     *
+     * @type {ThingTalk.SchemaRetriever}
+     * @readonly
+     */
     get schemas() {
         return this._schemas;
     }
-};
+}
+module.exports = BaseEngine; 

--- a/lib/base_platform.js
+++ b/lib/base_platform.js
@@ -9,104 +9,156 @@
 // See LICENSE for details
 "use strict";
 
-module.exports = class BasePlatform {
+/**
+ * The base class of the Almond platform layers.
+ *
+ * All platform specific APIs should be accessed through an instance of this class.
+ */
+class BasePlatform {
+    /**
+     * @protected
+     */
+    constructor() {}
+
     /* istanbul ignore next */
+    /**
+     * A semi-opaque identifier of the type of platform.
+     *
+     * @type {string}
+     * @readonly
+     */
     get type() {
         throw new Error('not implemented');
     }
 
-    /**
-      Retrieve the locale of the current user, as a BCP 47 tag.
-     */
     /* istanbul ignore next */
+    /**
+     * Retrieve the locale of the current user, as a BCP 47 tag.
+     *
+     * @type {string}
+     * @readonly
+     */
     get locale() {
         throw new Error('not implemented');
     }
 
-    /**
-      Retrieve the preferred timezone of the current user.
-     */
     /* istanbul ignore next */
+    /**
+     * Retrieve the preferred timezone of the current user.
+     *
+     * @type {string}
+     * @readonly
+     */
     get timezone() {
         throw new Error('not implemented');
     }
 
-    /**
-      Check if this platform has the required capability
-      (e,g. long running, big storage, reliable connectivity, server
-      connectivity, stable IP, local device discovery, bluetooth, etc.)
-    */
     /* istanbul ignore next */
+    /**
+     * Check if this platform has the required capability
+     * (e,g. long running, big storage, reliable connectivity, server
+     * connectivity, stable IP, local device discovery, bluetooth, etc.)
+     *
+     * @param {string} cap - the capability name
+     * @return {boolean} true if the capability name is known and supported, false otherwise
+    */
     hasCapability(cap) {
         throw new Error('not implemented');
     }
 
-    /**
-      Retrieve an interface to an optional functionality provided by the
-      platform.
-
-      This will return null if hasCapability(cap) is false
-    */
     /* istanbul ignore next */
+    /**
+     * Retrieve an interface to an optional functionality provided by the
+     * platform.
+     *
+     * This will return `null` if {@link BasePlatform#hasCapability}(cap) is `false`.
+     *
+     * @param {string} cap - the capability name
+     * @return {any|null} an interface implementing the given capability
+     */
     getCapability(cap) {
         throw new Error('not implemented');
     }
 
-    /**
-      Obtain a shared preference store
-
-      Preferences are simple per-user key/value store which is shared across all devices
-      but private to this instance (tier) of the platform.
-    */
     /* istanbul ignore next */
+    /**
+     * Obtain the shared preference store.
+     *
+     * Preferences are simple per-user key/value store which is shared across all devices
+     * but private to this instance (tier) of the platform.
+     *
+     * @return {Preferences} the shared preference store.
+     */
     getSharedPreferences() {
         throw new Error('not implemented');
     }
 
-    /**
-      Get a directory that is guaranteed to be writable
-      (in the private data space for Android)
-     */
     /* istanbul ignore next */
+    /**
+     * Get a directory that is guaranteed to be writable
+     * (in the private data space for Android)
+     *
+     * @return {string} a directory path
+     */
     getWritableDir() {
         throw new Error('not implemented');
     }
 
-    /**
-      Get a temporary directory
-      Guaranteed to be writable, but not guaranteed
-      to persist across reboots or for long times
-      (ie, it could be periodically cleaned by the system)
-    */
     /* istanbul ignore next */
+    /**
+     * Get a temporary directory.
+     *
+     * Guaranteed to be writable, but not guaranteed
+     * to persist across reboots or for long times
+     * (i.e., it could be periodically cleaned by the system).
+     *
+     * @return {string} a directory path
+     */
     getTmpDir() {
         throw new Error('not implemented');
     }
 
-    /**
-      Get a directory good for long term caching of code
-      and metadata.
-     */
     /* istanbul ignore next */
+    /**
+     * Get a directory good for long term caching of code
+     * and metadata.
+     *
+     * @return {string} a directory path
+     */
     getCacheDir() {
         throw new Error('not implemented');
     }
 
-    /**
-      Get the Thingpedia developer key, if one is configured
-     */
     /* istanbul ignore next */
+    /**
+     * Get the Thingpedia developer key, if one is configured.
+     *
+     * @return {string|null} the configured developer key, or null
+     */
     getDeveloperKey() {
         throw new Error('not implemented');
     }
 
     /* istanbul ignore next */
+    /**
+     * Retrieve the HTTP origin to use for OAuth redirects.
+     *
+     * @return {string} an HTTP origin (protocol, hostname and port)
     getOrigin() {
         throw new Error('not implemented');
     }
 
     /* istanbul ignore next */
+    /**
+     * Retrieve the unique ID of the user in the cloud platform.
+     *
+     * This is used to identify the same user across multiple devices
+     * running Almond (e.g. a phone and a home server).
+     *
+     * @return {string|null} an opaque unique ID
+     */
     getCloudId() {
         throw new Error('not implemented');
     }
-};
+}
+module.exports = BasePlatform; 

--- a/lib/config_delegate.js
+++ b/lib/config_delegate.js
@@ -15,6 +15,8 @@
  *
  * This class exists mostly for documentation, it's not actually used
  * because JS does not have interfaces or multiple inheritance.
+ *
+ * @interface
  */
 class ConfigDelegate {
     /**

--- a/lib/config_delegate.js
+++ b/lib/config_delegate.js
@@ -9,41 +9,64 @@
 // See LICENSE for details
 "use strict";
 
-// the base class of all the operations that a device is allowed
-// to perform to interact with the user during interactive configuration
+/**
+ * The base class of all the operations that a device is allowed
+ * to perform to interact with the user during interactive configuration.
+ *
+ * This class exists mostly for documentation, it's not actually used
+ * because JS does not have interfaces or multiple inheritance.
+ */
+class ConfigDelegate {
+    /**
+     * @protected
+     */
+    constructor() {}
 
-// this class exists mostly for documentation, it's not actually used
-// because JS does not have interfaces or multiple inheritance
-
-module.exports = class ConfigDelegate {
-    // report that the device was configured successfully
-    // this method is deprecated: returning successfully from
-    // completeDiscovery/loadInteractively is enough to report success
     /* istanbul ignore next */
-    configDone() {
+    /**
+     * Report that the device was configured successfully.
+     *
+     * @deprecated returning successfully from {@link BaseDevice#completeDiscovery} or
+     *             {@link BaseDevice.loadInteractively} is enough to report success.
+     */
+    async configDone() {
         throw new Error('Not Implemented');
     }
 
-    // inform the user that discovery/configuration failed
-    // for some reason
-    // this method is deprecated: throwing an exception from
-    // completeDiscovery/loadInteractively is enough to report failure
     /* istanbul ignore next */
+    /**
+     * Inform the user that discovery/configuration failed
+     * for some reason.
+     *
+     * @param {Error} error - the error that occurred
+     * @deprecated throwing an exception from {@link BaseDevice#completeDiscovery}
+     *             {@link BaseDevice.loadInteractively} is enough to report failure.
+     */
     configFailed(error) {
         throw new Error('Not Implemented');
     }
 
-    // ask the user a yes/no question
-    // returns a promise with boolean value
     /* istanbul ignore next */
-    confirm(question) {
+    /**
+     * Ask the user a yes/no question.
+     *
+     * @param {string} question - the question to ask
+     * @result {boolean} true if the user says yes, false if the user says no, or an error
+     */
+    async confirm(question) {
         throw new Error('Not Implemented');
     }
 
-    // ask the user for a PIN code/password
-    // returns a promise of a string
     /* istanbul ignore next */
-    requestCode(question) {
+    /**
+     * Ask the user for a PIN code/password.
+     *
+     * @param {string} question - the question to ask
+     * @param {boolean} [secret] - true if the question is secret (the answer should be masked)
+     * @result {string} the answer from the user
+     */
+    async requestCode(question, secret = false) {
         throw new Error('Not Implemented');
     }
-};
+}
+module.exports = ConfigDelegate; 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -8,15 +8,24 @@
 // See LICENSE for details
 "use strict";
 
+/**
+ * An error occurred during OAuth.
+ */
 class OAuthError extends Error {
 }
 
+/**
+ * The implementation of a device has a programming error (e.g. a missing function).
+ */
 class ImplementationError extends Error {
     constructor(msg) {
         super(`Implementation Error: ${msg}`);
     }
 }
 
+/**
+ * Some functionality or command is not available in this version of Almond.
+ */
 class UnsupportedError extends Error {
     constructor() {
         super(`This command is not available in this version of Almond`);

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -11,45 +11,126 @@
 
 const ModuleDownloader = require('./downloader');
 
-module.exports = class DeviceFactory {
+/**
+ * Factory class that can create device instances.
+ *
+ * Users of Thingpedia (that is, Almond engine implementors) must never create instances directly,
+ * and must always use this class. This ensures that all Thingpedia interfaces have the correct
+ * metadata and the correct default methods.
+ */
+class DeviceFactory {
+    /**
+     * Construct a new DeviceFactory.
+     *
+     * @param {BaseEngine} engine - the engine that will be passed to newly constructed devices
+     * @param {BaseClient} client - the client to use to contact Thingpedia
+     * @param {Object} [builtins] - implementation of builtin classes
+     */
     constructor(engine, client, builtins) {
         this._engine = engine;
         this._downloader = new ModuleDownloader(engine.platform, client, engine.schemas, builtins);
     }
 
+    /**
+     * Retrieve the list of cached device classes.
+     *
+     * @return {Object[]} the list of device classes
+     * @async
+     */
     getCachedDeviceClasses() {
         return this._downloader.getCachedMetas();
     }
 
+    /**
+     * Update the cached device class with the given ID.
+     *
+     * @param {string} kind - the class identifier to update
+     * @async
+     */
     updateDeviceClass(kind) {
         return this._downloader.updateModule(kind);
     }
 
+    /**
+     * Retrieve the device class with the given ID, fully initialized.
+     *
+     * @param {string} - the class identifier to retrieve
+     * @return {Class.<BaseDevice>}
+     * @async
+     */
     getDeviceClass(kind) {
         return this._downloader.getModule(kind)
             .then((module) => module.getDeviceClass());
     }
 
+    /**
+     * Load a new device of the given class ID using an OAuth-like flow.
+     *
+     * See {@link BaseDevice.loadFromCustomOAuth} for details
+     *
+     * @param {string} - the class identifier to load
+     * @return {Array} - a tuple with redirect URL and session
+     */
     loadFromOAuth(kind) {
         return this.getDeviceClass(kind).then((deviceClass) => deviceClass.loadFromCustomOAuth(this._engine));
     }
+    /**
+     * Complete configuring a new device using an OAuth-like flow.
+     *
+     * See {@link BaseDevice.completeCustomOAuth} for details
+     *
+     * @param {string} - the class identifier to load
+     * @param {string} - the OAuth redirect URL
+     * @param {Object.<string,string>} - the session object
+     * @return {BaseDevice} - the newly configured device
+     */
     completeOAuth(kind, url, session) {
         return this.getDeviceClass(kind).then((deviceClass) => deviceClass.completeCustomOAuth(this._engine, url, session));
     }
 
+    /**
+     * Load a new device of the given class ID using an interactive flow.
+     *
+     * See {@link BaseDevice.loadInteractively} for details
+     *
+     * @param {string} - the class identifier to load
+     * @param {ConfigDelegate} - the delegate to use for configuration
+     * @return {BaseDevice} - the newly configured device
+     */
     loadInteractively(kind, delegate) {
         return this.getDeviceClass(kind).then((deviceClass) => deviceClass.loadInteractively(this._engine, delegate));
     }
 
+    /**
+     * Load a new device of the given class ID using a discovery protocol.
+     *
+     * The returned device is not fully initialized, and the caller must call
+     * {@link BaseDevice#completeDiscovery} to finish initialization.
+     * See {@link BaseDevice.loadFromDiscovery} for details.
+     *
+     * @param {string} - the class identifier to load
+     * @param {Object} publicData - protocol specific data that is public (e.g. Bluetooth UUIDs)
+     * @param {Object} privateData - protocol specific data that is specific to the device and
+     *                               private to the user (e.g. Bluetooth HW address)
+     * @return {BaseDevice} - the partially configured device
+     */
     loadFromDiscovery(kind, publicData, privateData) {
         return this.getDeviceClass(kind).then((deviceClass) =>
             deviceClass.loadFromDiscovery(this._engine, publicData, privateData));
     }
 
+    /**
+     * Load a new device of the given class ID from its serialized state.
+     *
+     * @param {string} - the class identifier to load
+     * @param {Object} - the serialized state
+     * @return {BaseDevice} - the initialized device
+     */
     loadSerialized(kind, serializedDevice) {
         return this.getDeviceClass(kind).then((deviceClass) => {
             return new deviceClass(this._engine, serializedDevice);
         });
     }
-};
-module.exports.prototype.$rpcMethods = ['runOAuth2', 'getCachedModules'];
+}
+DeviceFactory.prototype.$rpcMethods = ['runOAuth2', 'getCachedModules'];
+module.exports = DeviceFactory;

--- a/lib/file_thingpedia_client.js
+++ b/lib/file_thingpedia_client.js
@@ -15,7 +15,21 @@ const fs = require('fs');
 const util = require('util');
 const BaseClient = require('./base_client');
 
-module.exports = class FileThingpediaClient extends BaseClient {
+/**
+ * A Thingpedia Client backed by local files.
+ *
+ * @extends BaseClient
+ */
+class FileClient extends BaseClient {
+    /**
+     * Construct a new FileClient.
+     *
+     * @param {Object} args - construction parameters
+     * @param {string} args.locale - the locale of the user
+     * @param {string} args.thingpedia - the path to the `thingpedia.tt` file
+     * @param {string} [args.entities] - the path to the `entities.json` file
+     * @param {string} [args.dataset] - the path to the `dataset.tt` file
+     */
     constructor(args) {
         super();
         this._locale = args.locale;
@@ -130,4 +144,5 @@ module.exports = class FileThingpediaClient extends BaseClient {
         await this._ensureLoaded();
         return this._entities;
     }
-};
+}
+module.exports = FileClient; 

--- a/lib/helpers/content.js
+++ b/lib/helpers/content.js
@@ -20,7 +20,7 @@ const HttpHelpers = require('./http');
  * These APIs should be used in preference to other libraries to support platform-specific
  * URLs, like `file:///` or `content://` URLs.
  *
- * @alias module:Helpers.Content
+ * @alias Helpers.Content
  * @namespace
  */
 module.exports = {
@@ -28,7 +28,7 @@ module.exports = {
      * Check if the given URL is publicly accessible, that is, if it can be accessed on
      * by a different server not running inside the current Almond.
      *
-     * Use this method to skip calling {@link module:Helpers.Content.getStream} or similar APIs if the
+     * Use this method to skip calling {@link Helpers.Content.getStream} or similar APIs if the
      * underlying API also support taking a URL instead of a data stream.
      * This method returns `true` for private, pre-authenticated URLs.
      *
@@ -47,7 +47,7 @@ module.exports = {
     /**
      * Stream the content of the given URL.
      *
-     * This method to should be used in preference to {@link module:Helpers.Http} or other
+     * This method to should be used in preference to {@link Helpers.Http} or other
      * libraries, in order to support platform-specific URLs.
      *
      * @param {BasePlatform} platform - the current Almond platform
@@ -73,7 +73,7 @@ module.exports = {
     /**
      * Buffer the content of the given URL.
      *
-     * This method is identical to {@link module:Helpers.Content.getStream} but returns a `Buffer` instead of a `stream.Readable`.
+     * This method is identical to {@link Helpers.Content.getStream} but returns a `Buffer` instead of a `stream.Readable`.
      *
      * @param {BasePlatform} platform - the current Almond platform
      * @param {string} url - the URL to retrieve

--- a/lib/helpers/content.js
+++ b/lib/helpers/content.js
@@ -14,7 +14,27 @@ const ip = require('ip');
 
 const HttpHelpers = require('./http');
 
+/**
+ * Utilities to download and stream content.
+ *
+ * These APIs should be used in preference to other libraries to support platform-specific
+ * URLs, like `file:///` or `content://` URLs.
+ *
+ * @alias module:Helpers.Content
+ * @namespace
+ */
 module.exports = {
+    /**
+     * Check if the given URL is publicly accessible, that is, if it can be accessed on
+     * by a different server not running inside the current Almond.
+     *
+     * Use this method to skip calling {@link module:Helpers.Content.getStream} or similar APIs if the
+     * underlying API also support taking a URL instead of a data stream.
+     * This method returns `true` for private, pre-authenticated URLs.
+     *
+     * @param {string} url - the URL to check
+     * @return {boolean} `true` if the URL is an http(s) URL for a public hostname or IP
+     */
     isPubliclyAccessible(url) {
         var parsed = Url.parse(url);
         if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
@@ -24,7 +44,18 @@ module.exports = {
         return ip.isPublic(parsed.hostname);
     },
 
-    getStream(platform, url) {
+    /**
+     * Stream the content of the given URL.
+     *
+     * This method to should be used in preference to {@link module:Helpers.Http} or other
+     * libraries, in order to support platform-specific URLs.
+     *
+     * @param {BasePlatform} platform - the current Almond platform
+     * @param {string} url - the URL to retrieve
+     * @return {stream.Readable} - a nodejs Readable stream, which also has a `contentType` string property
+     * @async
+     */
+    async getStream(platform, url) {
         if (url.startsWith('http')) {
             return HttpHelpers.getStream(url).then((stream) => {
                 stream.contentType = stream.headers['content-type'];
@@ -39,7 +70,17 @@ module.exports = {
         return Promise.resolve(contentApi.getStream(url));
     },
 
-    getData(platform, url) {
+    /**
+     * Buffer the content of the given URL.
+     *
+     * This method is identical to {@link module:Helpers.Content.getStream} but returns a `Buffer` instead of a `stream.Readable`.
+     *
+     * @param {BasePlatform} platform - the current Almond platform
+     * @param {string} url - the URL to retrieve
+     * @return {Buffer} - the buffered URL content; it also has a `contentType` string property
+     * @async
+     */
+    async getData(platform, url) {
         return this.getStream(platform, url).then((stream) => new Promise((callback, errback) => {
             var buffers = [];
             var length = 0;

--- a/lib/helpers/file_prefs.js
+++ b/lib/helpers/file_prefs.js
@@ -14,12 +14,23 @@ const fs = require('fs');
 
 const Preferences = require('../prefs');
 
-// Simple implementation of Preferences that uses a single file
-module.exports = class FilePreferences extends Preferences {
-    constructor(file, writeTimeout) {
+/**
+ * A simple implementation of {@link Preferences} that uses a single file.
+ *
+ * @alias module:Helpers.FilePreferences
+ * @extends Preferences
+ */
+class FilePreferences extends Preferences {
+    /**
+     * Construct a new FilePreferences object.
+     *
+     * @param {string} file - the file to write to
+     * @param {number} [writeTimeout=100] - timeout after which writes will be persisted on disk (in ms)
+     */
+    constructor(file, writeTimeout = 100) {
         super();
         this._file = file;
-        this._writeTimeout = writeTimeout === undefined ? 100 : writeTimeout;
+        this._writeTimeout = writeTimeout;
         try {
             this._prefs = JSON.parse(fs.readFileSync(file, 'utf8'));
         } catch(e) {
@@ -84,4 +95,5 @@ module.exports = class FilePreferences extends Preferences {
             this.flush();
         }, this._writeTimeout);
     }
-};
+}
+module.exports = FilePreferences;

--- a/lib/helpers/file_prefs.js
+++ b/lib/helpers/file_prefs.js
@@ -17,7 +17,7 @@ const Preferences = require('../prefs');
 /**
  * A simple implementation of {@link Preferences} that uses a single file.
  *
- * @alias module:Helpers.FilePreferences
+ * @alias Helpers.FilePreferences
  * @extends Preferences
  */
 class FilePreferences extends Preferences {

--- a/lib/helpers/http.js
+++ b/lib/helpers/http.js
@@ -163,7 +163,7 @@ function httpDownloadStream(url, method, data, options) {
  * HTTP Helpers.
  *
  * @namespace
- * @alias module:Helpers.Http
+ * @alias Helpers.Http
  */
 module.exports = {
     /**
@@ -251,7 +251,7 @@ module.exports = {
     /**
      * Perform a stream HTTP POST request.
      *
-     * The response will be buffered as with {@link module:Helpers.Http.post}.
+     * The response will be buffered as with {@link Helpers.Http.post}.
      *
      * @param {string} url - the URL to POST to
      * @param {string|null} data - the content of the request body; you can pass `null` for an empty body

--- a/lib/helpers/http.js
+++ b/lib/helpers/http.js
@@ -159,10 +159,145 @@ function httpDownloadStream(url, method, data, options) {
     return httpRequestStream(url, method, data, options, false, true);
 }
 
+/**
+ * HTTP Helpers.
+ *
+ * @namespace
+ * @alias module:Helpers.Http
+ */
 module.exports = {
+    /**
+     * Perform a buffered HTTP request with a custom method.
+     *
+     * @param {string} url - the URL to POST to
+     * @param {string} method - the HTTP method to use
+     * @param {string|null} data - the content of the request body; you can pass `null` for an empty body
+     * @param {Object} [options] - request options
+     * @param {string} [options.dataContentType] - the value of the `Content-Type` request header
+     * @param {string} [options.auth] - the value of `Authorization` header
+     * @param {string} [options.accept] - the value of `Accept` header
+     * @param {BaseDevice} [options.useOAuth2] - if set, the `Authorization` header will be computed for the passed
+     *                                           device based on the OAuth 2.0 standard; using this option also enables
+     *                                           automatic refresh token handling (if the refresh token exists); this
+     *                                           option is ignored if `auth` is also set
+     * @param {string} [options.authMethod=Bearer] - set this to override the prefix of the `Authorization` header;
+     *                                        this option is ignored unless `useOAuth2` is set
+     * @param {string} [options.user-agent] - set the `User-Agent` header; if unset a default user agent is used
+     * @param {Object.<string,string>} [options.extraHeaders] - other request headers to set
+     * @param {boolean} [options.ignoreErrors=false] - set to `true` to ignore errors (HTTP statuses 300 and higher)
+     * @param {boolean} [options.followRedirects=true] - set to `false` to disable automatic handling of HTTP redirects (status 301, 302 and 303)
+     * @param {boolean} [options.raw=false] - return the binary response body instead of converting to a string
+     * @return {string|Array} either the string response body, or a tuple with {@link Buffer} and content type.
+     * @function
+     * @async
+     */
     request: httpRequest,
+
+    /**
+     * Perform a buffered HTTP GET.
+     *
+     * If `options.raw` is set, returns a tuple of the response (as a `Buffer`) and the `Content-Type` header.
+     * Otherwise, it returns the response body as a string.
+     * If the HTTP request fails (returns a status code greater or equal to 300), the promise is rejected.
+     * The resulting `Error` object will have a `code` property containing the actual HTTP status code.
+     * If the HTTP status code is a redirect (between 300 and 399 inclusive), the `redirect` property
+     * on the error will contain the value of the `Location` header.
+     *
+     * @param {string} url - the URL to retrieve
+     * @param {Object} [options] - request options
+     * @param {string} [options.auth] - the value of `Authorization` header
+     * @param {string} [options.accept] - the value of `Accept` header
+     * @param {BaseDevice} [options.useOAuth2] - if set, the `Authorization` header will be computed for the passed
+     *                                           device based on the OAuth 2.0 standard; using this option also enables
+     *                                           automatic refresh token handling (if the refresh token exists); this
+     *                                           option is ignored if `auth` is also set
+     * @param {string} [options.authMethod=Bearer] - set this to override the prefix of the `Authorization` header;
+     *                                        this option is ignored unless `useOAuth2` is set
+     * @param {string} [options.user-agent] - set the `User-Agent` header; if unset a default user agent is used
+     * @param {Object.<string,string>} [options.extraHeaders] - other request headers to set
+     * @param {boolean} [options.ignoreErrors=false] - set to `true` to ignore errors (HTTP statuses 300 and higher)
+     * @param {boolean} [options.followRedirects=true] - set to `false` to disable automatic handling of HTTP redirects (status 301, 302 and 303)
+     * @param {boolean} [options.raw=false] - return the binary response body instead of converting to a string
+     * @return {string|Array} either the string response body, or a tuple with {@link Buffer} and content type.
+     * @async
+     */
     get(url, options) { return httpRequest(url, 'GET', null, options); },
+
+    /**
+     * Perform a buffered HTTP POST.
+     *
+     * @param {string} url - the URL to POST to
+     * @param {string|null} data - the content of the request body; you can pass `null` for an empty body
+     * @param {Object} [options] - request options
+     * @param {string} [options.dataContentType] - the value of the `Content-Type` request header
+     * @param {string} [options.auth] - the value of `Authorization` header
+     * @param {string} [options.accept] - the value of `Accept` header
+     * @param {BaseDevice} [options.useOAuth2] - if set, the `Authorization` header will be computed for the passed
+     *                                           device based on the OAuth 2.0 standard; using this option also enables
+     *                                           automatic refresh token handling (if the refresh token exists); this
+     *                                           option is ignored if `auth` is also set
+     * @param {string} [options.authMethod=Bearer] - set this to override the prefix of the `Authorization` header;
+     *                                        this option is ignored unless `useOAuth2` is set
+     * @param {string} [options.user-agent] - set the `User-Agent` header; if unset a default user agent is used
+     * @param {Object.<string,string>} [options.extraHeaders] - other request headers to set
+     * @param {boolean} [options.ignoreErrors=false] - set to `true` to ignore errors (HTTP statuses 300 and higher)
+     * @param {boolean} [options.followRedirects=true] - set to `false` to disable automatic handling of HTTP redirects (status 301, 302 and 303)
+     * @param {boolean} [options.raw=false] - return the binary response body instead of converting to a string
+     * @return {string|Array} either the string response body, or a tuple with {@link Buffer} and content type.
+     * @async
+     */
     post(url, data, options) { return httpRequest(url, 'POST', data, options); },
+
+    /**
+     * Perform a stream HTTP POST request.
+     *
+     * The response will be buffered as with {@link module:Helpers.Http.post}.
+     *
+     * @param {string} url - the URL to POST to
+     * @param {string|null} data - the content of the request body; you can pass `null` for an empty body
+     * @param {Object} [options] - request options
+     * @param {string} [options.dataContentType] - the value of the `Content-Type` request header
+     * @param {string} [options.auth] - the value of `Authorization` header
+     * @param {string} [options.accept] - the value of `Accept` header
+     * @param {BaseDevice} [options.useOAuth2] - if set, the `Authorization` header will be computed for the passed
+     *                                           device based on the OAuth 2.0 standard; using this option also enables
+     *                                           automatic refresh token handling (if the refresh token exists); this
+     *                                           option is ignored if `auth` is also set
+     * @param {string} [options.authMethod=Bearer] - set this to override the prefix of the `Authorization` header;
+     *                                        this option is ignored unless `useOAuth2` is set
+     * @param {string} [options.user-agent] - set the `User-Agent` header; if unset a default user agent is used
+     * @param {Object.<string,string>} [options.extraHeaders] - other request headers to set
+     * @param {boolean} [options.ignoreErrors=false] - set to `true` to ignore errors (HTTP statuses 300 and higher)
+     * @param {boolean} [options.followRedirects=true] - set to `false` to disable automatic handling of HTTP redirects (status 301, 302 and 303)
+     * @param {boolean} [options.raw=false] - return the binary response body instead of converting to a string
+     * @return {string|Array} either the string response body, or a tuple with {@link Buffer} and content type.
+     * @async
+     */
     postStream(url, data, options) { return httpUploadStream(url, 'POST', data, options); },
+
+    /**
+     * Perform a streaming GET request.
+     *
+     *
+     * The result is the [`http.IncomingMessage`](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+     * from the underlying nodejs HTTP API. The result is also a `stream.Readable` and can be used as such.
+     *
+     * @param {string} url - the URL to retrieve
+     * @param {Object} [options] - request options
+     * @param {string} [options.auth] - the value of `Authorization` header
+     * @param {string} [options.accept] - the value of `Accept` header
+     * @param {BaseDevice} [options.useOAuth2] - if set, the `Authorization` header will be computed for the passed
+     *                                           device based on the OAuth 2.0 standard; using this option also enables
+     *                                           automatic refresh token handling (if the refresh token exists); this
+     *                                           option is ignored if `auth` is also set
+     * @param {string} [options.authMethod=Bearer] - set this to override the prefix of the `Authorization` header;
+     *                                        this option is ignored unless `useOAuth2` is set
+     * @param {string} [options.user-agent] - set the `User-Agent` header; if unset a default user agent is used
+     * @param {Object.<string,string>} [options.extraHeaders] - other request headers to set
+     * @param {boolean} [options.ignoreErrors=false] - set to `true` to ignore errors (HTTP statuses 300 and higher)
+     * @param {boolean} [options.followRedirects=true] - set to `false` to disable automatic handling of HTTP redirects (status 301, 302 and 303)
+     * @return {http.IncomingMessage} the server response
+     * @async
+     */
     getStream(url, options) { return httpDownloadStream(url, 'GET', null, options); },
 };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -9,6 +9,15 @@
 // See LICENSE for details
 "use strict";
 
+/**
+ * A collection of useful helper libraries bundled with the SDK.
+ *
+ * It is recommended, although not required, to use the following libraries
+ * instead of custom bundled libraries.
+ *
+ * @module Helpers
+ */
+
 module.exports = {
     Content: require('./content'),
     Http: require('./http'),

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -15,7 +15,8 @@
  * It is recommended, although not required, to use the following libraries
  * instead of custom bundled libraries.
  *
- * @module Helpers
+ * @namespace
+ * @name Helpers
  */
 
 module.exports = {

--- a/lib/helpers/object_set.js
+++ b/lib/helpers/object_set.js
@@ -14,19 +14,19 @@ const events = require('events');
 /**
  * The abstract interface that all ObjectSets must conform to.
  *
- * @memberof! module:Helpers.ObjectSet
+ * @memberof! Helpers.ObjectSet
  */
 class Base extends events.EventEmitter {
     /**
      * Notifies that an object was to this set.
      *
-     * @event module:Helpers.ObjectSet.Base#object-added
+     * @event Helpers.ObjectSet.Base#object-added
      * @param {Object} object - the added object
      */
     /**
      * Notifies that an object was removed from this set.
      *
-     * @event module:Helpers.ObjectSet.Base#object-removed
+     * @event Helpers.ObjectSet.Base#object-removed
      * @param {Object} object - the just-removed object
      */
 
@@ -42,7 +42,7 @@ class Base extends events.EventEmitter {
      * Report the addition of an object.
      *
      * @param {Object} o - the added object
-     * @fires module:Helpers.ObjectSet.Base#object-added
+     * @fires Helpers.ObjectSet.Base#object-added
      * @protected
      */
     objectAdded(o) {
@@ -53,7 +53,7 @@ class Base extends events.EventEmitter {
      * Report the removal of an object.
      *
      * @param {Object} o - the removed object
-     * @fires module:Helpers.ObjectSet.Base#object-removed
+     * @fires Helpers.ObjectSet.Base#object-removed
      * @protected
      */
     objectRemoved(o) {
@@ -97,10 +97,10 @@ class Base extends events.EventEmitter {
 }
 
 /**
- * A simple implementation of {@link module:Helpers.ObjectSet.Base} backed by a {@link Map}.
+ * A simple implementation of {@link Helpers.ObjectSet.Base} backed by a {@link Map}.
  *
- * @extends module:Helpers.ObjectSet.Base
- * @memberof! module:Helpers.ObjectSet
+ * @extends Helpers.ObjectSet.Base
+ * @memberof! Helpers.ObjectSet
  */
 class Simple extends Base {
     constructor() {
@@ -193,7 +193,7 @@ class Simple extends Base {
  * and removal.
  *
  * @namespace
- * @alias module:Helpers.ObjectSet
+ * @alias Helpers.ObjectSet
  */
 module.exports = {
     Simple,

--- a/lib/helpers/object_set.js
+++ b/lib/helpers/object_set.js
@@ -11,42 +11,98 @@
 
 const events = require('events');
 
-// The abstract interface that all ObjectSets must conform to
-//
-// Some ObjectSets are read-only, in which case the mutator methods will fail
-class ObjectSet extends events.EventEmitter {
-    // events: object-added(object), object-removed(object)
+/**
+ * The abstract interface that all ObjectSets must conform to.
+ *
+ * @memberof! module:Helpers.ObjectSet
+ */
+class Base extends events.EventEmitter {
+    /**
+     * Notifies that an object was to this set.
+     *
+     * @event module:Helpers.ObjectSet.Base#object-added
+     * @param {Object} object - the added object
+     */
+    /**
+     * Notifies that an object was removed from this set.
+     *
+     * @event module:Helpers.ObjectSet.Base#object-removed
+     * @param {Object} object - the just-removed object
+     */
 
+    /**
+     * @protected
+     */
     constructor() {
         super();
         this.setMaxListeners(Infinity);
     }
 
+    /**
+     * Report the addition of an object.
+     *
+     * @param {Object} o - the added object
+     * @fires module:Helpers.ObjectSet.Base#object-added
+     * @protected
+     */
     objectAdded(o) {
         this.emit('object-added', o);
     }
 
+    /**
+     * Report the removal of an object.
+     *
+     * @param {Object} o - the removed object
+     * @fires module:Helpers.ObjectSet.Base#object-removed
+     * @protected
+     */
     objectRemoved(o) {
         this.emit('object-removed', o);
     }
 
     /* istanbul ignore next */
+    /**
+     * List all objects currently in the set.
+     *
+     * @return {Object[]} - the objects in the set
+     * @abstract
+     */
     values() {
         throw new Error('Not Implemented');
     }
 
     /* istanbul ignore next */
-    start() {
+    /**
+     * Start this object set.
+     *
+     * This should be called for ObjectSets whose content
+     * changes dynamically.
+     * @abstract
+     */
+    async start() {
         throw new Error('Not Implemented');
     }
 
     /* istanbul ignore next */
-    stop() {
+    /**
+     * Stop this object set.
+     *
+     * This should be called for ObjectSets whose content
+     * changes dynamically.
+     * @abstract
+     */
+    async stop() {
         throw new Error('Not Implemented');
     }
 }
 
-class SimpleObjectSet extends ObjectSet {
+/**
+ * A simple implementation of {@link module:Helpers.ObjectSet.Base} backed by a {@link Map}.
+ *
+ * @extends module:Helpers.ObjectSet.Base
+ * @memberof! module:Helpers.ObjectSet
+ */
+class Simple extends Base {
     constructor() {
         super();
 
@@ -132,7 +188,14 @@ class SimpleObjectSet extends ObjectSet {
     }
 }
 
+/**
+ * ObjectSet is an abstract set data structure that can be monitored for additions
+ * and removal.
+ *
+ * @namespace
+ * @alias module:Helpers.ObjectSet
+ */
 module.exports = {
-    Simple: SimpleObjectSet,
-    Base: ObjectSet
+    Simple,
+    Base
 };

--- a/lib/helpers/polling.js
+++ b/lib/helpers/polling.js
@@ -16,7 +16,7 @@ const stream = require('stream');
  *
  * The callback should poll the underlying API and return the current results.
  *
- * @callback module:Helpers~PollCallback
+ * @callback Helpers~PollCallback
  * @return {Object[]} the current list of results
  */
 
@@ -24,7 +24,7 @@ const stream = require('stream');
  * A stream.Readable implementation that emits new values at specific interval.
  *
  * @extends stream.Readable
- * @alias module:Helpers.PollingStream
+ * @alias Helpers.PollingStream
  */
 class PollingStream extends stream.Readable {
     /**
@@ -32,7 +32,7 @@ class PollingStream extends stream.Readable {
      *
      * @param {TriggerStateBinder} state - a state binder object
      * @param {number} interval - polling interval, in milliseconds
-     * @param {module:Helpers~PollCallback} callback - function to call every poll interval
+     * @param {Helpers~PollCallback} callback - function to call every poll interval
      */
     constructor(state, interval, callback) {
         super({ objectMode: true });

--- a/lib/helpers/polling.js
+++ b/lib/helpers/polling.js
@@ -11,7 +11,29 @@
 
 const stream = require('stream');
 
-module.exports = class PollingStream extends stream.Readable {
+/**
+ * Callback called when polling.
+ *
+ * The callback should poll the underlying API and return the current results.
+ *
+ * @callback module:Helpers~PollCallback
+ * @return {Object[]} the current list of results
+ */
+
+/**
+ * A stream.Readable implementation that emits new values at specific interval.
+ *
+ * @extends stream.Readable
+ * @alias module:Helpers.PollingStream
+ */
+class PollingStream extends stream.Readable {
+    /**
+     * Construct a new polling stream.
+     *
+     * @param {TriggerStateBinder} state - a state binder object
+     * @param {number} interval - polling interval, in milliseconds
+     * @param {module:Helpers~PollCallback} callback - function to call every poll interval
+     */
     constructor(state, interval, callback) {
         super({ objectMode: true });
 
@@ -22,6 +44,9 @@ module.exports = class PollingStream extends stream.Readable {
         this._destroyed = false;
     }
 
+    /**
+     * Destroy the current stream (stop polling).
+     */
     destroy() {
         if (this._timeout === null)
             return;
@@ -65,5 +90,5 @@ module.exports = class PollingStream extends stream.Readable {
         if (this._timeout === null)
             this._nextTimeout();
     }
-};
-
+}
+module.exports = PollingStream;

--- a/lib/helpers/ref_counted.js
+++ b/lib/helpers/ref_counted.js
@@ -26,13 +26,13 @@ async function pFinally(promise, finallyClause) {
  * a file or a socket) in a deterministic manner among multiple users.
  *
  * @extends events.EventEmitter
- * @alias module:Helpers.RefCounted
+ * @alias Helpers.RefCounted
  */
 class RefCounted extends events.EventEmitter {
     /**
      * Construct a new reference counted object.
      *
-     * The object has initial reference count of 0. You must call {@link module:Helpers.RefCounted#open} before use.
+     * The object has initial reference count of 0. You must call {@link Helpers.RefCounted#open} before use.
      *
      * @protected
      */

--- a/lib/helpers/ref_counted.js
+++ b/lib/helpers/ref_counted.js
@@ -19,7 +19,23 @@ async function pFinally(promise, finallyClause) {
     }
 }
 
-module.exports = class RefCounted extends events.EventEmitter {
+/**
+ * Base class for an object that has reference-counting.
+ *
+ * This class can be used to manage the lifetime of some resource (like
+ * a file or a socket) in a deterministic manner among multiple users.
+ *
+ * @extends events.EventEmitter
+ * @alias module:Helpers.RefCounted
+ */
+class RefCounted extends events.EventEmitter {
+    /**
+     * Construct a new reference counted object.
+     *
+     * The object has initial reference count of 0. You must call {@link module:Helpers.RefCounted#open} before use.
+     *
+     * @protected
+     */
     constructor() {
         super();
         this.setMaxListeners(0);
@@ -29,13 +45,36 @@ module.exports = class RefCounted extends events.EventEmitter {
         this._closePromise = null;
     }
 
-    _doOpen() {
-        return Promise.resolve();
-    }
-    _doClose() {
-        return Promise.resolve();
+    /**
+     * Open a reference to the underlying resource.
+     *
+     * This method is called when the reference count goes from 0 to 1.
+     *
+     * @abstract
+     * @protected
+     */
+    async _doOpen() {
     }
 
+    /**
+     * Release the underlying resource.
+     *
+     * This method is called when the reference count goes from 1 to 0.
+     *
+     * @abstract
+     * @protected
+     */
+    async _doClose() {
+    }
+
+    /**
+     * Obtain a reference to the underlying resource.
+     *
+     * This method ensures that the resource is initialized, and increases
+     * the reference count.
+     *
+     * @async
+     */
     open() {
         // if closing, wait to fully close then reopen
         if (this._closePromise) {
@@ -60,6 +99,14 @@ module.exports = class RefCounted extends events.EventEmitter {
         }
     }
 
+    /**
+     * Release a reference to the underlying resource.
+     *
+     * This method decreases the reference count, and releases the resource
+     * if there are no other users.
+     *
+     * @async
+     */
     close() {
         // if opening, wait to fully open then close
         if (this._openPromise) {
@@ -84,4 +131,5 @@ module.exports = class RefCounted extends events.EventEmitter {
             return Promise.resolve();
         }
     }
-};
+}
+module.exports = RefCounted;

--- a/lib/helpers/rss.js
+++ b/lib/helpers/rss.js
@@ -13,7 +13,35 @@ const FeedParser = require('feedparser');
 
 const Http = require('./http');
 
+/**
+ * RSS entry returned by the helpers.
+ *
+ * @typedef {Object} module:Helpers.Rss~RSSEntry
+ * @property {string} guid - the GUID of the RSS entry
+ * @property {string} title - the title of the RSS entry
+ * @property {Date} updated_time - the time at which this RSS entry was updated
+ * @property {string} link - the link to the underlying article
+ * @property {string|null} description - the body of the RSS entry, if present and plain text
+ * @property {string|null} author - the author of the RSS entry, if present
+ * @property {string|null} picture_url - the image associated with this entry, if one is present
+ * @property {string[]} categories - categories associated with this RSS entry
+ */
+
+/**
+ * RSS helpers.
+ *
+ * @namespace
+ * @alias module:Helpers.Rss
+ */
 module.exports = {
+    /**
+     * Retrieve and parse and RSS feed.
+     *
+     * @param {string} url - the URL of the feed
+     * @param {Object} options - options to pass to the HTTP library; see {@link module:Helpers.Http.get} for details
+     * @return {Array.<module:Helpers.Rss~RSSEntry>} a list of RSS entries
+     * @async
+     */
     get(url, options) {
         return Http.getStream(url, options).then((stream) => {
             return new Promise((resolve, reject) => {

--- a/lib/helpers/rss.js
+++ b/lib/helpers/rss.js
@@ -16,7 +16,7 @@ const Http = require('./http');
 /**
  * RSS entry returned by the helpers.
  *
- * @typedef {Object} module:Helpers.Rss~RSSEntry
+ * @typedef {Object} Helpers.Rss~RSSEntry
  * @property {string} guid - the GUID of the RSS entry
  * @property {string} title - the title of the RSS entry
  * @property {Date} updated_time - the time at which this RSS entry was updated
@@ -31,15 +31,15 @@ const Http = require('./http');
  * RSS helpers.
  *
  * @namespace
- * @alias module:Helpers.Rss
+ * @alias Helpers.Rss
  */
 module.exports = {
     /**
      * Retrieve and parse and RSS feed.
      *
      * @param {string} url - the URL of the feed
-     * @param {Object} options - options to pass to the HTTP library; see {@link module:Helpers.Http.get} for details
-     * @return {Array.<module:Helpers.Rss~RSSEntry>} a list of RSS entries
+     * @param {Object} options - options to pass to the HTTP library; see {@link Helpers.Http.get} for details
+     * @return {Array.<Helpers.Rss~RSSEntry>} a list of RSS entries
      * @async
      */
     get(url, options) {

--- a/lib/helpers/xml.js
+++ b/lib/helpers/xml.js
@@ -12,6 +12,22 @@
 const xml2js = require('xml2js');
 const util = require('util');
 
+/**
+ * XML parsing helpers.
+ *
+ * This module exists to expose the bundled  [xml2js](https://www.npmjs.com/package/xml2js)
+ * dependency to Thingpedia interfaces, so that they don't need to bundle it themselves.
+ *
+ * @namespace
+ * @alias module:Helpers.Xml
+ */
 module.exports = {
+    /**
+     * Parse the given XML document using xml2js.
+     *
+     * @param {string} xml - the XML to parse
+     * @return {Object} the parsed document
+     * @async
+     */
     parseString: util.promisify(xml2js.parseString)
 };

--- a/lib/helpers/xml.js
+++ b/lib/helpers/xml.js
@@ -19,7 +19,7 @@ const util = require('util');
  * dependency to Thingpedia interfaces, so that they don't need to bundle it themselves.
  *
  * @namespace
- * @alias module:Helpers.Xml
+ * @alias Helpers.Xml
  */
 module.exports = {
     /**

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -17,13 +17,30 @@ const ClientBase = require('./base_client');
 
 const DEFAULT_THINGPEDIA_URL = 'https://thingpedia.stanford.edu/thingpedia';
 
-module.exports = class ThingpediaClientHttp extends ClientBase {
+/**
+ * A Thingpedia Client that communicates with Thingpedia over HTTP(S).
+ *
+ * @extends BaseClient
+ */
+class HttpClient extends ClientBase {
+    /**
+     * Construct a new HttpClient.
+     *
+     * @param {BasePlatform} platform - the platform owning this client
+     * @param {string} [url] - the Thingpedia URL to use
+     */
     constructor(platform, url = DEFAULT_THINGPEDIA_URL) {
         super();
         this.platform = platform;
         this._url = url + '/api/v3';
     }
 
+    /**
+     * Retrieve the current user's developer key.
+     *
+     * @type {string|null}
+     * @readonly
+     */
     get developerKey() {
         return this.platform.getDeveloperKey();
     }
@@ -140,4 +157,5 @@ module.exports = class ThingpediaClientHttp extends ClientBase {
     getAllEntityTypes() {
         return this._simpleRequest('/entities/all');
     }
-};
+}
+module.exports = HttpClient; 

--- a/lib/prefs.js
+++ b/lib/prefs.js
@@ -18,7 +18,7 @@ const events = require('events');
  * consistency, durability or scalability. Use it only for small amounts of data
  * that has little value.
  *
- * This is backed by {@link module:Helpers.FilePreferences} in most platforms, and by Android's `SharedPreferences`
+ * This is backed by {@link Helpers.FilePreferences} in most platforms, and by Android's `SharedPreferences`
  * on Android.
  *
  * @extends events.EventEmitter

--- a/lib/prefs.js
+++ b/lib/prefs.js
@@ -12,56 +12,79 @@
 const events = require('events');
 
 /**
-  A simple persistent key-value store.
-
-  The store is designed to be fast and easy to use, and makes little guarantees of
-  consistency, durability or scalability. Use it only for small amounts of data
-  that has little value.
-
-  This is backed by Helpers.FilePreferences in most platforms, and by Android's SharedPreferences
-  on Android.
-*/
-module.exports = class Preferences extends events.EventEmitter {
+ * A simple persistent key-value store.
+ *
+ * The store is designed to be fast and easy to use, and makes little guarantees of
+ * consistency, durability or scalability. Use it only for small amounts of data
+ * that has little value.
+ *
+ * This is backed by {@link module:Helpers.FilePreferences} in most platforms, and by Android's `SharedPreferences`
+ * on Android.
+ *
+ * @extends events.EventEmitter
+ */
+class Preferences extends events.EventEmitter {
+    /* istanbul ignore next */
     /**
-      List all names in this preference store.
-    */
+     * List all names in this preference store.
+     *
+     * @return {String[]}
+     * @abstract
+     */
     keys() {
         return [];
     }
 
-    /**
-      Retrieve the named preference, or undefined if there is no stored value for it
-    */
     /* istanbul ignore next */
+    /**
+     * Retrieve the named preference, or undefined if there is no stored value for it
+     *
+     * @param {string} name - the preference name
+     * @return {any} - the value, or `undefined`
+     * @abstract
+     */
     get(name) {
         return undefined;
     }
 
-    /**
-      Set the named preference to the given value, which can be any object for which
-      a valid JSON representation exists (any non-cyclic object without non enumerable
-      properties)
-    */
     /* istanbul ignore next */
+    /**
+     * Set the named preference to the given value, which can be any object for which
+     * a valid JSON representation exists (any non-cyclic object without non enumerable
+     * properties)
+     *
+     * @param {string} name - the preference name
+     * @param {any} value - the value
+     * @abstract
+    */
     set(name, value) {
         throw new Error('Abstract method');
     }
 
-    /**
-      Remove the given preference key from the store.
-    */
     /* istanbul ignore next */
+    /**
+     * Remove the given preference key from the store.
+     *
+     * @param {string} name - the preference key to delete
+     * @abstract
+     */
     delete(name) {
         throw new Error('Abstract method');
     }
 
+    /* istanbul ignore next */
     /**
-      Mark the given preference name as changed.
-
-      This method should be called if the value is mutated without calling `set()`, for
-      example if the value is an object or array and some of its properties/indices are changed.
-    */
+     * Mark the given preference name as changed.
+     *
+     * This method should be called if the value is mutated without calling `set()`, for
+     * example if the value is an object or array and some of its properties/indices are changed.
+     *
+     * @param {string} [name] - which preference name changed; if omitted, all preferences will
+     *                          be considered changed
+     * @abstract
+     */
     changed(name) {
         throw new Error('Abstract method');
     }
-};
+}
+module.exports = Preferences; 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,6 +28,8 @@ function measureToString(value, precision, unit) {
   Split a textual chain of properties separated with . into an array of property names.
 
   Handles \ as escape character.
+
+  @private
 */
 function splitpropchain(propchainstring) {
     const chain = [];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint ./lib",
     "test": "nyc node ./test",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "doc": "jsdoc -c jsdoc.json -r index.js lib/"
+    "doc": "jsdoc -c jsdoc.json --readme README.md --package package.json --verbose -r index.js lib/"
   },
   "devDependencies": {
     "coveralls": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   "scripts": {
     "lint": "eslint ./lib",
     "test": "nyc node ./test",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "doc": "jsdoc -c jsdoc.json -r index.js lib/"
   },
   "devDependencies": {
     "coveralls": "^3.0.1",
     "eslint": "^6.0.0",
+    "jsdoc": "^3.6.3",
     "nyc": "^14.0.0",
     "qs": "^6.7.0",
     "tough-cookie": "^3.0.1"

--- a/test/test_content.js
+++ b/test/test_content.js
@@ -102,7 +102,7 @@ async function testGetFileStream() {
 }
 
 async function testGetFileStream2() {
-    assert.throws(() => Content.getStream(platformWithoutContent,
+    assert.rejects(() => Content.getStream(platformWithoutContent,
         'file://' + path.resolve(path.dirname(module.filename), 'test.txt')));
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,7 +51,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.2":
+"@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.6.0", "@babel/parser@^7.6.2":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
   integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
@@ -209,6 +209,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bluebird@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -246,6 +251,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+catharsis@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.11.tgz#d0eb3d2b82b7da7a3ce2efb1a7b00becc6643468"
+  integrity sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==
+  dependencies:
+    lodash "^4.17.14"
 
 chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
@@ -438,6 +450,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -479,6 +496,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -752,7 +774,7 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.9:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
@@ -1032,10 +1054,37 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js2xmlparser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.0.tgz#ae14cc711b2892083eed6e219fbc993d858bc3a5"
+  integrity sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==
+  dependencies:
+    xmlcreate "^2.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdoc@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.3.tgz#dccea97d0e62d63d306b8b3ed1527173b5e2190d"
+  integrity sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==
+  dependencies:
+    "@babel/parser" "^7.4.4"
+    bluebird "^3.5.4"
+    catharsis "^0.8.11"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.0"
+    klaw "^3.0.0"
+    markdown-it "^8.4.2"
+    markdown-it-anchor "^5.0.2"
+    marked "^0.7.0"
+    mkdirp "^0.5.1"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.0.1"
+    taffydb "2.6.2"
+    underscore "~1.9.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -1077,6 +1126,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
+
 lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
@@ -1089,6 +1145,13 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -1158,6 +1221,32 @@ make-dir@^2.0.0, make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+markdown-it-anchor@^5.0.2:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz#d39306fe4c199705b4479d3036842cf34dcba24f"
+  integrity sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==
+
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 merge-source-map@^1.1.0:
   version "1.1.0"
@@ -1576,6 +1665,13 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requizzle@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.3.tgz#4675c90aacafb2c036bd39ba2daa4a1cb777fded"
+  integrity sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==
+  dependencies:
+    lodash "^4.17.14"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1848,6 +1944,11 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
+  integrity sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=
+
 test-exclude@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
@@ -1938,6 +2039,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
 uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
@@ -1945,6 +2051,11 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
+
+underscore@~1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -2058,6 +2169,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlcreate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-2.0.1.tgz#2ec38bd7b708d213fd1a90e2431c4af9c09f6a52"
+  integrity sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Replace the hand-maintained and often out of date markdown-based reference in almond-cloud with jsdoc comments.

Note: this is only for the reference manual. Guides and tutorials will continue using markdown.