### PR TITLE
Import utilities to create device factories from almond-cloud

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const DeviceFactory = require('./lib/factory');
 const { ImplementationError, UnsupportedError } = require('./lib/errors');
 const BaseEngine = require('./lib/base_engine');
 const BasePlatform = require('./lib/base_platform');
-const DeviceFactoryUtils = require('./lib/device_factory_utils');
+const DeviceConfigUtils = require('./lib/device_factory_utils');
 
 const ThingTalk = require('thingtalk');
 
@@ -87,7 +87,7 @@ module.exports = {
     HttpClient,
     FileClient,
     DeviceFactory,
-    DeviceFactoryUtils,
+    DeviceConfigUtils,
 
     // expose errors
     ImplementationError,

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const DeviceFactory = require('./lib/factory');
 const { ImplementationError, UnsupportedError } = require('./lib/errors');
 const BaseEngine = require('./lib/base_engine');
 const BasePlatform = require('./lib/base_platform');
+const DeviceFactoryUtils = require('./lib/device_factory_utils');
 
 const ThingTalk = require('thingtalk');
 
@@ -86,6 +87,7 @@ module.exports = {
     HttpClient,
     FileClient,
     DeviceFactory,
+    DeviceFactoryUtils,
 
     // expose errors
     ImplementationError,

--- a/lib/device_factory_utils.js
+++ b/lib/device_factory_utils.js
@@ -70,7 +70,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'discovery',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name,
             discoveryType: 'bluetooth'
         };
@@ -78,7 +78,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'discovery',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name,
             discoveryType: 'upnp'
         };
@@ -87,7 +87,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'interactive',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name
         };
 
@@ -95,7 +95,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'none',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name
         };
 
@@ -104,7 +104,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'oauth2',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name
         };
 
@@ -112,7 +112,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'form',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name,
             fields: toFields(getInputParam(config, 'params'))
         };
@@ -121,7 +121,7 @@ function makeDeviceFactory(classDef, device) {
         return {
             type: 'form',
             category: device.category,
-            kind: device.primary_kind,
+            kind: classDef.kind,
             text: device.name,
             fields: [
                 { name: 'username', label: 'Username', type: 'text' },

--- a/lib/device_factory_utils.js
+++ b/lib/device_factory_utils.js
@@ -1,0 +1,176 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Thingpedia
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+function clean(name) {
+    if (/^[vwgp]_/.test(name))
+        name = name.substr(2);
+    return name.replace(/_/g, ' ').replace(/([^A-Z ])([A-Z])/g, '$1 $2').toLowerCase();
+}
+
+function entityTypeToHTMLType(type) {
+    switch (type) {
+    case 'tt:password':
+        return 'password';
+    case 'tt:url':
+        return 'url';
+    case 'tt:phone_number':
+        return 'tel';
+    case 'tt:email_address':
+        return 'email';
+    default:
+        return 'text';
+    }
+}
+
+function getInputParam(config, name) {
+    for (let inParam of config.in_params) {
+        if (inParam.name === name)
+            return inParam.value.toJS();
+    }
+    return undefined;
+}
+
+function makeDeviceFactory(classDef, device) {
+    if (classDef.is_abstract)
+        return null;
+
+    const config = classDef.config;
+
+    function toFields(argMap) {
+        if (!argMap)
+            return [];
+        return Object.keys(argMap).map((k) => {
+            const type = argMap[k];
+            let htmlType;
+            if (type.isEntity)
+                htmlType = entityTypeToHTMLType(type.type);
+            else if (type.isNumber || type.isMeasure)
+                htmlType = 'number';
+            else if (type.isBoolean)
+                htmlType = 'checkbox';
+            else
+                htmlType = 'text';
+            return { name: k, label: clean(k), type: htmlType };
+        });
+    }
+
+    switch (config.module) {
+    case 'org.thingpedia.config.builtin':
+        return null;
+
+    case 'org.thingpedia.config.discovery.bluetooth':
+        return {
+            type: 'discovery',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name,
+            discoveryType: 'bluetooth'
+        };
+    case 'org.thingpedia.config.discovery.upnp':
+        return {
+            type: 'discovery',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name,
+            discoveryType: 'upnp'
+        };
+
+    case 'org.thingpedia.config.interactive':
+        return {
+            type: 'interactive',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name
+        };
+
+    case 'org.thingpedia.config.none':
+        return {
+            type: 'none',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name
+        };
+
+    case 'org.thingpedia.config.oauth2':
+    case 'org.thingpedia.config.custom_oauth':
+        return {
+            type: 'oauth2',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name
+        };
+
+    case 'org.thingpedia.config.form':
+        return {
+            type: 'form',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name,
+            fields: toFields(getInputParam(config, 'params'))
+        };
+
+    case 'org.thingpedia.config.basic_auth':
+        return {
+            type: 'form',
+            category: device.category,
+            kind: device.primary_kind,
+            text: device.name,
+            fields: [
+                { name: 'username', label: 'Username', type: 'text' },
+                { name: 'password', label: 'Password', type: 'password' }
+            ].concat(toFields(getInputParam(config, 'extra_params')))
+        };
+
+    default:
+        throw new Error(`Unrecognized config mixin ${config.module}`);
+    }
+}
+
+function getDiscoveryServices(classDef) {
+    if (classDef.is_abstract)
+        return [];
+
+    const config = classDef.config;
+    switch (config.module) {
+    case 'org.thingpedia.config.discovery.bluetooth': {
+        const uuids = getInputParam(config, 'uuids');
+        const deviceClass = getInputParam(config, 'device_class');
+
+        const services = uuids.map((u) => {
+            return {
+                discovery_type: 'bluetooth',
+                service: 'uuid-' + u.toLowerCase()
+            };
+        });
+        if (deviceClass) {
+            services.push({
+                discovery_type: 'bluetooth',
+                service: 'class-' + deviceClass
+            });
+        }
+        return services;
+    }
+    case 'org.thingpedia.config.discovery.upnp':
+        return getInputParam(config, 'search_target').map((st) => {
+            return {
+                discovery_type: 'upnp',
+                service: st.toLowerCase().replace(/^urn:/, '').replace(/:/g, '-')
+            };
+        });
+    default:
+        return [];
+    }
+}
+
+module.exports = {
+    makeDeviceFactory,
+    getDiscoveryServices
+};

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ async function seq(array) {
 
 seq([
     ('./test_unit'),
+    ('./test_device_factories'),
     ('./test_string_format'),
     ('./test_version'),
     ('./test_class'),

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ async function seq(array) {
 seq([
     ('./test_unit'),
     ('./test_device_factories'),
+    ('./test_discovery_services'),
     ('./test_string_format'),
     ('./test_version'),
     ('./test_class'),

--- a/test/test_device_factories.js
+++ b/test/test_device_factories.js
@@ -15,6 +15,19 @@ const ThingTalk = require('thingtalk');
 const DeviceFactoryUtils = require('../lib/device_factory_utils');
 
 const TEST_CASES = [
+    [`abstract class @security-camera {}`, {
+        name: 'Security Camera',
+        category: 'physical',
+    }, null],
+
+    [`class @org.thingpedia.builtin.thingengine.builtin {
+        import loader from @org.thingpedia.builtin();
+        import config from @org.thingpedia.config.builtin();
+    }`, {
+        name: 'Security Camera',
+        category: 'physical',
+    }, null],
+
     [`class @com.bing {
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.none();
@@ -43,6 +56,23 @@ const TEST_CASES = [
             { name: 'username', label: 'Username', type: 'text' },
             { name: 'password', label: 'Password', type: 'password' },
             { name: 'serial_number', label: 'serial number', type: 'text' },
+        ]
+    }],
+
+    [`class @com.bodytrace.scale2 {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.basic_auth();
+    }`, {
+        name: "BodyTrace Scale",
+        category: 'physical',
+    }, {
+        type: 'form',
+        text: "BodyTrace Scale",
+        kind: 'com.bodytrace.scale2',
+        category: 'physical',
+        fields: [
+            { name: 'username', label: 'Username', type: 'text' },
+            { name: 'password', label: 'Password', type: 'password' }
         ]
     }],
 

--- a/test/test_device_factories.js
+++ b/test/test_device_factories.js
@@ -19,7 +19,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.none();
     }`, {
-        primary_kind: "com.bing",
         name: "Bing Search",
         category: 'data',
     }, {
@@ -33,7 +32,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.basic_auth(extra_params=makeArgMap(serial_number : String));
     }`, {
-        primary_kind: "com.bodytrace.scale",
         name: "BodyTrace Scale",
         category: 'physical',
     }, {
@@ -69,7 +67,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.custom_oauth();
     }`, {
-        primary_kind: "com.twitter",
         name: "Twitter Account",
         category: 'online',
     }, {
@@ -83,7 +80,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.oauth2(client_id="foo", client_secret="bar");
     }`, {
-        primary_kind: "com.linkedin",
         name: "LinkedIn Account",
         category: 'online',
     }, {
@@ -97,7 +93,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.discovery.upnp(search_target=['urn:lge:com:service:webos:second-screen-1']);
     }`, {
-        primary_kind: "com.lg.tv.webos2",
         name: "LG TV",
         category: 'physical',
     }, {
@@ -112,7 +107,6 @@ const TEST_CASES = [
         import loader from @org.thingpedia.v2();
         import config from @org.thingpedia.config.discovery.bluetooth(uuids=['0000110b-0000-1000-8000-00805f9b34fb']);
     }`, {
-        primary_kind: "org.thingpedia.bluetooth.speaker.a2dp",
         name: "Bluetooth Speaker",
         category: 'physical',
     }, {

--- a/test/test_device_factories.js
+++ b/test/test_device_factories.js
@@ -1,0 +1,148 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond Cloud
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+const ThingTalk = require('thingtalk');
+
+const DeviceFactoryUtils = require('../lib/device_factory_utils');
+
+const TEST_CASES = [
+    [`class @com.bing {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.none();
+    }`, {
+        primary_kind: "com.bing",
+        name: "Bing Search",
+        category: 'data',
+    }, {
+        type: 'none',
+        text: "Bing Search",
+        kind: 'com.bing',
+        category: 'data'
+    }],
+
+    [`class @com.bodytrace.scale {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.basic_auth(extra_params=makeArgMap(serial_number : String));
+    }`, {
+        primary_kind: "com.bodytrace.scale",
+        name: "BodyTrace Scale",
+        category: 'physical',
+    }, {
+        type: 'form',
+        text: "BodyTrace Scale",
+        kind: 'com.bodytrace.scale',
+        category: 'physical',
+        fields: [
+            { name: 'username', label: 'Username', type: 'text' },
+            { name: 'password', label: 'Password', type: 'password' },
+            { name: 'serial_number', label: 'serial number', type: 'text' },
+        ]
+    }],
+
+    [`class @org.thingpedia.rss {
+        import loader from @org.thingpedia.rss();
+        import config from @org.thingpedia.config.form(params=makeArgMap(url : Entity(tt:url)));
+    }`, {
+        primary_kind: "org.thingpedia.rss",
+        name: "RSS Feed",
+        category: 'data',
+    }, {
+        type: 'form',
+        text: "RSS Feed",
+        kind: 'org.thingpedia.rss',
+        category: 'data',
+        fields: [
+            { name: 'url', label: 'url', type: 'url' },
+        ]
+    }],
+
+    [`class @com.twitter {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.custom_oauth();
+    }`, {
+        primary_kind: "com.twitter",
+        name: "Twitter Account",
+        category: 'online',
+    }, {
+        type: 'oauth2',
+        text: "Twitter Account",
+        kind: 'com.twitter',
+        category: 'online',
+    }],
+
+    [`class @com.linkedin {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.oauth2(client_id="foo", client_secret="bar");
+    }`, {
+        primary_kind: "com.linkedin",
+        name: "LinkedIn Account",
+        category: 'online',
+    }, {
+        type: 'oauth2',
+        text: "LinkedIn Account",
+        kind: 'com.linkedin',
+        category: 'online',
+    }],
+
+    [`class @com.lg.tv.webos2 {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.discovery.upnp(search_target=['urn:lge:com:service:webos:second-screen-1']);
+    }`, {
+        primary_kind: "com.lg.tv.webos2",
+        name: "LG TV",
+        category: 'physical',
+    }, {
+        type: 'discovery',
+        text: "LG TV",
+        kind: 'com.lg.tv.webos2',
+        category: 'physical',
+        discoveryType: 'upnp'
+    }],
+
+    [`class @org.thingpedia.bluetooth.speaker.a2dp {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.discovery.bluetooth(uuids=['0000110b-0000-1000-8000-00805f9b34fb']);
+    }`, {
+        primary_kind: "org.thingpedia.bluetooth.speaker.a2dp",
+        name: "Bluetooth Speaker",
+        category: 'physical',
+    }, {
+        type: 'discovery',
+        text: "Bluetooth Speaker",
+        kind: 'org.thingpedia.bluetooth.speaker.a2dp',
+        category: 'physical',
+        discoveryType: 'bluetooth'
+    }],
+];
+
+async function testCase(i) {
+    console.log(`Test Case #${i+1}`);
+    const [classCode, device, expectedFactory] = TEST_CASES[i];
+
+    const classDef = ThingTalk.Grammar.parse(classCode).classes[0];
+    const generatedFactory = DeviceFactoryUtils.makeDeviceFactory(classDef, device);
+
+    try {
+        assert.deepStrictEqual(generatedFactory, expectedFactory);
+    } catch(e) {
+        console.error('Failed: ' + e.message);
+        if (process.env.TEST_MODE)
+            throw e;
+    }
+}
+async function main() {
+    for (let i = 0; i < TEST_CASES.length; i++)
+        await testCase(i);
+}
+module.exports = main;
+if (!module.parent)
+    main();

--- a/test/test_discovery_services.js
+++ b/test/test_discovery_services.js
@@ -1,0 +1,63 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond Cloud
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+const ThingTalk = require('thingtalk');
+
+const DeviceFactoryUtils = require('../lib/device_factory_utils');
+
+const TEST_CASES = [
+    [`abstract class @security-camera {}`, []],
+
+    [`class @com.bing {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.none();
+    }`, []],
+
+    [`class @com.lg.tv.webos2 {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.discovery.upnp(search_target=['urn:lge:com:service:webos:second-screen-1']);
+    }`, [{
+        discovery_type: 'upnp',
+        service: 'lge-com-service-webos-second-screen-1'
+    }]],
+
+    [`class @org.thingpedia.bluetooth.speaker.a2dp {
+        import loader from @org.thingpedia.v2();
+        import config from @org.thingpedia.config.discovery.bluetooth(uuids=['0000110b-0000-1000-8000-00805f9b34fb']);
+    }`, [{
+        discovery_type: 'bluetooth',
+        service: 'uuid-0000110b-0000-1000-8000-00805f9b34fb'
+    }]],
+];
+
+async function testCase(i) {
+    console.log(`Test Case #${i+1}`);
+    const [classCode, expectedServices] = TEST_CASES[i];
+
+    const classDef = ThingTalk.Grammar.parse(classCode).classes[0];
+    const generatedServices = DeviceFactoryUtils.getDiscoveryServices(classDef);
+
+    try {
+        assert.deepStrictEqual(generatedServices, expectedServices);
+    } catch(e) {
+        console.error('Failed: ' + e.message);
+        if (process.env.TEST_MODE)
+            throw e;
+    }
+}
+async function main() {
+    for (let i = 0; i < TEST_CASES.length; i++)
+        await testCase(i);
+}
+module.exports = main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
This is code that has been copied to almond-cmdline and almond-server
to implement "developer mode", and it's best if shared. Also,
this simplifies adding new kinds of loaders or config modules,
cause almond-cloud no longer needs to change.