### PR TITLE
FileThingpediaClient: fix getExamplesByKinds

### DIFF
--- a/lib/file_thingpedia_client.js
+++ b/lib/file_thingpedia_client.js
@@ -9,6 +9,7 @@
 // See COPYING for details
 "use strict";
 
+const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const fs = require('fs');
@@ -111,16 +112,16 @@ class FileClient extends BaseClient {
     }
 
     async getExamplesByKinds(kinds) {
+        assert(Array.isArray(kinds));
         await this._ensureLoaded();
-        const devices = kinds.split(',');
 
         let examples = [];
-        for (let device of devices) {
+        for (let device of kinds) {
             if (device in this._examples)
                 examples = examples.concat(this._examples[device]);
         }
 
-        const name = `@org.thingpedia.dynamic.by_kinds.${devices.join('__')}`;
+        const name = `@org.thingpedia.dynamic.by_kinds.${kinds.join('__')}`;
         let dataset = new Ast.Dataset(name, 'en', examples, {});
         let library = new Ast.Input.Library([], [dataset]);
         return library.prettyprint();

--- a/test/test_file_client.js
+++ b/test/test_file_client.js
@@ -116,7 +116,7 @@ async function testGetExamples() {
         ex.preprocessed.forEach((p) => assertNonEmptyString(p));
     }
 
-    const bing = ThingTalk.Grammar.parse(await _fileClient.getExamplesByKinds('com.bing,com.google'));
+    const bing = ThingTalk.Grammar.parse(await _fileClient.getExamplesByKinds(['com.bing', 'com.google']));
     assert(bing.isLibrary);
     assert.strictEqual(bing.classes.length, 0);
     assert.strictEqual(bing.datasets.length, 1);


### PR DESCRIPTION
It should take an array of kinds, not a single string separated
by commas