### PR TITLE
content: recognize more URLs as non publicly accessible

### DIFF
--- a/lib/helpers/content.js
+++ b/lib/helpers/content.js
@@ -39,9 +39,23 @@ module.exports = {
         var parsed = Url.parse(url);
         if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
             return false;
-        if (!ip.isV4Format(parsed.hostname) && !ip.isV6Format(parsed.hostname))
-            return true;
-        return ip.isPublic(parsed.hostname);
+
+        if (ip.isV4Format(parsed.hostname) || ip.isV6Format(parsed.hostname))
+            return ip.isPublic(parsed.hostname);
+
+        // single-label DNS names (without a dot) are resolved according to the "search"
+        // setting in /etc/resolv.conf, so we treat them as private
+        const parts = parsed.hostname.split('.');
+        if (parts.length === 1)
+            return false;
+
+        // hostnames that end in .local, .localhost, .localdomain, .invalid, .onion are
+        // also special (RFC 6761, RFC 6762, RFC 7686)
+        // (.localdomain is not RFC specified but it is commonly used)
+        if (['local', 'localhost', 'localdomain', 'invalid', 'onion'].indexOf(parts[parts.length-1]) >= 0)
+            return false;
+
+        return true;
     },
 
     /**

--- a/test/test_content.js
+++ b/test/test_content.js
@@ -64,7 +64,17 @@ async function testIsPubliclyAccessible() {
     assert(!Content.isPubliclyAccessible('file:///home/user/foo'));
     assert(!Content.isPubliclyAccessible('http://127.0.0.1/foo'));
     assert(!Content.isPubliclyAccessible('http://192.168.1.1/foo'));
+    assert(Content.isPubliclyAccessible('http://171/foo'));
     assert(!Content.isPubliclyAccessible('http://[::1]/foo'));
+    assert(!Content.isPubliclyAccessible('http://[fe80::1]/foo'));
+    assert(Content.isPubliclyAccessible('http://171.64.72.12/foo'));
+    assert(!Content.isPubliclyAccessible('http://parmesan/foo'));
+    assert(Content.isPubliclyAccessible('http://parmesan.stanford.edu/foo'));
+    assert(!Content.isPubliclyAccessible('http://xxxxxx.onion/foo'));
+    assert(!Content.isPubliclyAccessible('http://localhost/foo'));
+    assert(!Content.isPubliclyAccessible('http://localhost.localdomain/foo'));
+    assert(!Content.isPubliclyAccessible('http://foo.localhost/foo'));
+    assert(!Content.isPubliclyAccessible('http://foo.invalid/foo'));
 }
 
 const CROWDIE = `<!DOCTYPE html>


### PR DESCRIPTION
Access to these URLs needs to go through the content API
on the server that originates them, and these URLs cannot
be passed around.