### PR TITLE
Add developer dir support

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -26,6 +26,15 @@ function safeMkdir(dir) {
     }
 }
 
+function safeSymlinkSync(from, to) {
+    try {
+        fs.symlinkSync(from, to, 'dir');
+    } catch(e) {
+        if (e.code !== 'EEXIST')
+            throw e;
+    }
+}
+
 module.exports = class ModuleDownloader {
     constructor(platform, client, schemas, builtins = {}, options = {}) {
         this._platform = platform;
@@ -43,19 +52,15 @@ module.exports = class ModuleDownloader {
         safeMkdir(this._cacheDir + '/node_modules');
 
         if (platform.type !== 'android') {
-            try {
-                fs.symlinkSync(path.dirname(require.resolve('..')),
-                               this._cacheDir + '/node_modules/thingpedia', 'dir');
-            } catch(e) {
-                if (e.code !== 'EEXIST')
-                    throw e;
-            }
-            try {
-                fs.symlinkSync(path.dirname(require.resolve('thingtalk')),
-                               this._cacheDir + '/node_modules/thingtalk', 'dir');
-            } catch(e) {
-                if (e.code !== 'EEXIST')
-                    throw e;
+            safeSymlinkSync(path.dirname(require.resolve('..')), this._cacheDir + '/node_modules/thingpedia');
+            safeSymlinkSync(path.dirname(require.resolve('thingtalk')), this._cacheDir + '/node_modules/thingtalk');
+
+            const prefs = platform.getSharedPreferences();
+            const developerDir = prefs.get('developer-dir');
+            if (developerDir) {
+                safeMkdir(developerDir + '/node_modules');
+                safeSymlinkSync(path.dirname(require.resolve('..')), developerDir + '/node_modules/thingpedia');
+                safeSymlinkSync(path.dirname(require.resolve('thingtalk')), developerDir + '/node_modules/thingtalk');
             }
         }
     }
@@ -126,8 +131,18 @@ module.exports = class ModuleDownloader {
         if (this._builtins[id])
             return this._builtins[id].class;
 
-        var manifestTmpPath = this._cacheDir + '/' + id + '.tt.tmp';
-        var manifestPath = this._cacheDir + '/' + id + '.tt';
+        // if there is a developer directory, and it contains a manifest for the current device, load
+        // it directly, bypassing the cache logic
+        const prefs = this._platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (developerDir && this._client._getLocalDeviceManifest) {
+            const localPath = path.resolve(developerDir, id, 'manifest.tt');
+            if (await util.promisify(fs.exists)(localPath))
+                return (await this._client._getLocalDeviceManifest(localPath, id)).prettyprint();
+        }
+
+        const manifestTmpPath = this._cacheDir + '/' + id + '.tt.tmp';
+        const manifestPath = this._cacheDir + '/' + id + '.tt';
 
         let useCached = false;
 

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -11,14 +11,21 @@
 
 const ThingTalk = require('thingtalk');
 const qs = require('querystring');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
 
 const Helpers = require('./helpers');
 const ClientBase = require('./base_client');
+const { makeDeviceFactory } = require('./device_factory_utils');
 
 const DEFAULT_THINGPEDIA_URL = 'https://thingpedia.stanford.edu/thingpedia';
 
 /**
  * A Thingpedia Client that communicates with Thingpedia over HTTP(S).
+ *
+ * If the developer-dir shared preference is set, HTTP results are overridden
+ * with the manifest.tt in the developer directory.
  *
  * @extends BaseClient
  */
@@ -49,7 +56,121 @@ class HttpClient extends ClientBase {
         return this.platform.locale;
     }
 
-    getModuleLocation(id) {
+    async _getLocalDeviceManifest(manifestPath, deviceKind) {
+        const ourMetadata = (await util.promisify(fs.readFile)(manifestPath)).toString();
+        const ourParsed = ThingTalk.Grammar.parse(ourMetadata);
+        ourParsed.classes[0].annotations.version = new ThingTalk.Ast.Value.Number(-1);
+
+        if (!ourParsed.classes[0].is_abstract) {
+            try {
+                const ourConfig = ourParsed.classes[0].config;
+                if (!ourConfig.in_params.some((v) => v.value.isUndefined))
+                    return ourParsed.classes[0];
+
+                // ourMetadata might lack some of the fields that are in the
+                // real metadata, such as api keys and OAuth secrets
+                // for that reason we fetch the metadata for thingpedia as well,
+                // and fill in any missing parameter
+                const officialMetadata = await this._getDeviceCodeHttp(deviceKind);
+                const officialParsed = ThingTalk.Grammar.parse(officialMetadata);
+
+                ourConfig.in_params = ourConfig.in_params.filter((ip) => !ip.value.isUndefined);
+                const ourConfigParams = new Set(ourConfig.in_params.map((ip) => ip.name));
+                const officialConfig = officialParsed.classes[0].config;
+
+                for (let in_param of officialConfig.in_params) {
+                    if (!ourConfigParams.has(in_param.name))
+                        ourConfig.in_params.push(in_param);
+                }
+
+            } catch(e) {
+                if (e.code !== 404)
+                    throw e;
+            }
+        }
+
+        return ourParsed.classes[0];
+    }
+
+    async getDeviceCode(id) {
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+
+        if (developerDir) {
+            const localPath = path.resolve(developerDir, id, 'manifest.tt');
+            if (await util.promisify(fs.exists)(localPath))
+                return (await this._getLocalDeviceManifest(localPath, id)).prettyprint();
+        }
+
+        return this._getDeviceCodeHttp(id);
+    }
+
+    async getModuleLocation(id) {
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (developerDir && await util.promisify(fs.exists)(path.resolve(developerDir, id)))
+            return 'file://' + path.resolve(developerDir, id);
+        else
+            return this._getModuleLocationHttp(id);
+    }
+
+    async getSchemas(kinds, withMetadata) {
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (!developerDir)
+            return this._getSchemasHttp(kinds, withMetadata);
+
+        const forward = [];
+        const handled = [];
+
+        for (let kind of kinds) {
+            const localPath = path.resolve(developerDir, kind, 'manifest.tt');
+            if (await util.promisify(fs.exists)(localPath))
+                handled.push(await this._getLocalDeviceManifest(localPath, kind));
+            else
+                forward.push(kind);
+        }
+
+        let code = '';
+        if (handled.length > 0)
+            code += new ThingTalk.Ast.Input.Library(handled, []).prettyprint();
+        if (forward.length > 0)
+            code += await this._getSchemasHttp(kinds, withMetadata);
+
+        return code;
+    }
+
+    async _getLocalFactory(localPath, kind) {
+        const classDef = await this._getLocalDeviceManifest(localPath, kind);
+        return makeDeviceFactory(classDef, {
+            category: 'data', // doesn't matter too much
+            name: classDef.metadata.thingpedia_name || classDef.metadata.name || kind,
+        });
+    }
+
+    async getDeviceSetup(kinds) {
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (!developerDir)
+            return this._getDeviceSetupHttp(kinds);
+
+        const forward = [];
+        const handled = {};
+        for (let kind of kinds) {
+            const localPath = path.resolve(developerDir, kind, 'manifest.tt');
+            if (await util.promisify(fs.exists)(localPath))
+                handled[kind] = await this._getLocalFactory(localPath, kind);
+            else
+                forward.push(kind);
+        }
+
+        if (forward.length > 0)
+            handled.assign(await this._getDeviceSetupHttp(forward));
+
+        return handled;
+    }
+
+    _getModuleLocationHttp(id) {
         var to = this._url + '/devices/package/' + id;
         if (this.developerKey)
             to += '?developer_key=' + this.developerKey;
@@ -84,11 +205,11 @@ class HttpClient extends ClientBase {
     }
 
     // raw manifest code
-    getDeviceCode(kind) {
+    _getDeviceCodeHttp(kind) {
         return this._simpleRequest('/devices/code/' + kind, {}, 'application/x-thingtalk');
     }
 
-    getSchemas(kinds, withMetadata) {
+    _getSchemasHttp(kinds, withMetadata) {
         return this._simpleRequest('/schema/' + kinds.join(','), {
             meta: withMetadata ? '1' : '0'
         }, 'application/x-thingtalk');
@@ -108,7 +229,7 @@ class HttpClient extends ClientBase {
         return this._simpleRequest('/devices/setup', params);
     }
 
-    getDeviceSetup(kinds) {
+    _getDeviceSetupHttp(kinds) {
         return this._simpleRequest('/devices/setup/' + kinds.join(','));
     }
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -109,6 +109,21 @@ function loadTextdomainDirectory(gt, locale, domain, podir) {
     }
 }
 
+class MockPreferences {
+    constructor() {
+        this._store = {};
+    }
+
+    get(name) {
+        return this._store[name];
+    }
+
+    set(name, value) {
+        console.log(`preferences set ${name} = ${value}`);
+        this._store[name] = value;
+    }
+}
+
 class MockPlatform extends BasePlatform {
     constructor(locale = 'en-US') {
         super();
@@ -122,6 +137,8 @@ class MockPlatform extends BasePlatform {
             let modir = path.resolve(path.dirname(module.filename), './po');//'
             loadTextdomainDirectory(this._gettext, this._locale, 'thingengine-core', modir);
         }
+
+        this._prefs = new MockPreferences();
     }
 
     get type() {
@@ -134,6 +151,9 @@ class MockPlatform extends BasePlatform {
         return 'America/Los_Angeles';
     }
 
+    getSharedPreferences() {
+        return this._prefs;
+    }
     getCacheDir() {
         return path.dirname(module.filename);
     }
@@ -199,4 +219,13 @@ function toClassDef(classCode) {
     return ThingTalk.Grammar.parse(classCode).classes[0];
 }
 
-module.exports = { MockPlatform, MockEngine, toClassDef, mockPlatform, mockClient, mockEngine, State };
+module.exports = {
+    MockPreferences,
+    MockPlatform,
+    MockEngine,
+    toClassDef,
+    mockPlatform,
+    mockClient,
+    mockEngine,
+    State
+};

--- a/test/test_http_client.js
+++ b/test/test_http_client.js
@@ -16,9 +16,17 @@ const ThingTalk = require('thingtalk');
 
 const HttpClient = require('../lib/http_client');
 
+const { MockPreferences } = require('./mock');
+
 const _mockPlatform = {
+    _prefs: new MockPreferences,
+
     getDeveloperKey() {
         return null;
+    },
+
+    getSharedPreferences() {
+        return this._prefs;
     },
 
     get locale() {
@@ -26,9 +34,15 @@ const _mockPlatform = {
     }
 };
 const _mockDeveloperPlatform = {
+    _prefs: new MockPreferences,
+
     getDeveloperKey() {
         // almond-dev developer key
         return '88c03add145ad3a3aa4074ffa828be5a391625f9d4e1d0b034b445f18c595656';
+    },
+
+    getSharedPreferences() {
+        return this._prefs;
     },
 
     get locale() {


### PR DESCRIPTION
This PR supersedes https://github.com/stanford-oval/almond-server/pull/31, but it does so in a way that solves the major issues with it:
- manifests are not cached in the normal cache directory if loaded from the developer directory
- developers no longer need to fiddle with yarn link to get the right thingpedia setup

It's very late for this PR, but if we don't merge it for 2.7 (1.8 cycle) running the homework will be very painful.