### PR TITLE
HttpClient: implement methods used by synthetic generation

### DIFF
--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -165,7 +165,7 @@ class HttpClient extends ClientBase {
         }
 
         if (forward.length > 0)
-            handled.assign(await this._getDeviceSetupHttp(forward));
+            Object.assign(handled, await this._getDeviceSetupHttp(forward));
 
         return handled;
     }
@@ -302,8 +302,21 @@ class HttpClient extends ClientBase {
         return this._simpleRequest('/examples/all', {}, 'application/x-thingtalk');
     }
 
-    getAllEntityTypes() {
-        return this._simpleRequest('/entities/all');
+    async getAllEntityTypes() {
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (!developerDir)
+            return this._simpleRequest('/entities/all');
+
+        const entities = await this._simpleRequest('/entities/all');
+        for (let device of await util.promisify(fs.readdir)(developerDir)) {
+            const localPath = path.resolve(developerDir, device, 'entities.json');
+            if (await util.promisify(fs.exists)(localPath)) {
+                const local = JSON.parse(await util.promisify(fs.readFile)(localPath, { encoding: 'utf8' }));
+                entities.push(...local.data);
+            }
+        }
+        return entities;
     }
 
     async getAllDeviceNames() {

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -252,7 +252,34 @@ class HttpClient extends ClientBase {
         return this._simpleRequest('/examples/search', { q: key }, 'application/x-thingtalk');
     }
 
-    getExamplesByKinds(kinds) {
+    async getExamplesByKinds(kinds) {
+        // we don't want to hammer the server and download the snapshot continuously, so
+        // we only return the devices in the developer directory
+
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (!developerDir)
+            return this._getExamplesByKinds(kinds);
+
+        const forward = [];
+        const handled = [];
+        for (let kind of kinds) {
+            const localPath = path.resolve(developerDir, kind, 'dataset.tt');
+            if (await util.promisify(fs.exists)(localPath))
+                handled.push(await util.promisify(fs.readFile)(localPath, { encoding: 'utf8' }));
+            else
+                forward.push(kind);
+        }
+
+        if (forward.length > 0)
+            handled.push(await this._getExamplesByKinds(forward));
+
+        const buffer = handled.join('\n');
+        console.log(buffer);
+        return buffer;
+    }
+
+    _getExamplesByKinds(kinds) {
         return this._simpleRequest('/examples/by-kinds/' + kinds.join(','), {}, 'application/x-thingtalk');
     }
 
@@ -277,6 +304,31 @@ class HttpClient extends ClientBase {
 
     getAllEntityTypes() {
         return this._simpleRequest('/entities/all');
+    }
+
+    async getAllDeviceNames() {
+        // we don't want to hammer the server and download the snapshot continuously, so
+        // we only return the devices in the developer directory
+
+        const prefs = this.platform.getSharedPreferences();
+        const developerDir = prefs.get('developer-dir');
+        if (!developerDir)
+            return [];
+
+        const names = [];
+
+        for (let device of await util.promisify(fs.readdir)(developerDir)) {
+            const localPath = path.resolve(developerDir, device, 'manifest.tt');
+            if (await util.promisify(fs.exists)(localPath)) {
+                const classDef = (await this._getLocalDeviceManifest(localPath, device));
+                names.push({
+                    kind: classDef.kind,
+                    kind_canonical: classDef.metadata.canonical
+                });
+            }
+        }
+
+        return names;
     }
 }
 module.exports = HttpClient; 


### PR DESCRIPTION
This way, we can use developer-dir support in combination with
the new dialogue patch for almond