### PR TITLE
Allow lazy implementations for query functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -114,7 +114,7 @@ rules:
         before: false
         after: true
       method:
-        before: false
+        before: true
         after: false
   '@typescript-eslint/type-annotation-spacing':
     - error

--- a/lib/loaders/base_js.js
+++ b/lib/loaders/base_js.js
@@ -34,7 +34,7 @@ import * as Helpers from '../helpers';
 
 function isIterable(result) {
     return typeof result === 'object' && result !== null &&
-        typeof result[Symbol.iterator] === 'function';
+        (typeof result[Symbol.iterator] === 'function' || typeof result[Symbol.asyncIterator] === 'function');
 }
 
 // wrap implementation functions in async functions
@@ -50,7 +50,7 @@ function safeWrapQuery(query, queryName) {
     return async function() {
         const result = await query.apply(this, arguments);
         if (!isIterable(result))
-            throw new ImplementationError(`The query ${queryName} must return an iterable object (eg. Array), got ${result}`);
+            throw new ImplementationError(`The query ${queryName} must return an async-iterable or iterable object (eg. Array), got ${result}`);
         return result;
     };
 }

--- a/test/device-classes/org.thingpedia.test.broken/index.js
+++ b/test/device-classes/org.thingpedia.test.broken/index.js
@@ -46,4 +46,9 @@ export default class MyDevice extends Tp.BaseDevice {
     get_something_poll4() {
         return 'foo';
     }
+
+    async *get_something_lazy() {
+        yield 1;
+        yield 2;
+    }
 }

--- a/test/test_v2_device.js
+++ b/test/test_v2_device.js
@@ -202,6 +202,9 @@ async function testBrokenDevices() {
     await assert.rejects(() => instance.get_something_poll3(), ImplementationError);
     await assert.rejects(() => instance.get_something_poll4(), ImplementationError);
     await assert.throws(() => instance.subscribe_something(), ImplementationError);
+
+    // this one doesn't return an iterable (it returns an async-iterable), but it's ok anyway
+    await instance.get_something_lazy();
 }
 
 async function testThingpedia() {


### PR DESCRIPTION
The syntax "async *get_foo()" allows to easily implement lazy get functions
that can be potentially return an unbounded number of results.
This is useful when converting database-style Thingpedia queries to API
calls, as rarely one API call can dump the whole database.