### PR TITLE
loaders: set '.manifest' property of generic device classes too

### DIFF
--- a/lib/loaders/base_generic.js
+++ b/lib/loaders/base_generic.js
@@ -43,6 +43,7 @@ module.exports = class BaseGenericModule {
         if (this._config)
             this._config.install(this._loaded);
 
+        this._loaded.manifest = this._manifest;
         this._loaded.metadata = makeBaseDeviceMetadata(this._manifest);
     }
 


### PR DESCRIPTION
thingpedia-common-devices uses this property in the tests