### PR TITLE
Add support for multiple developer dirs

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -55,12 +55,13 @@ module.exports = class ModuleDownloader {
             safeSymlinkSync(path.dirname(require.resolve('..')), this._cacheDir + '/node_modules/thingpedia');
             safeSymlinkSync(path.dirname(require.resolve('thingtalk')), this._cacheDir + '/node_modules/thingtalk');
 
-            const prefs = platform.getSharedPreferences();
-            const developerDir = prefs.get('developer-dir');
-            if (developerDir) {
-                safeMkdir(developerDir + '/node_modules');
-                safeSymlinkSync(path.dirname(require.resolve('..')), developerDir + '/node_modules/thingpedia');
-                safeSymlinkSync(path.dirname(require.resolve('thingtalk')), developerDir + '/node_modules/thingtalk');
+            const developerDirs = this._getDeveloperDirs();
+            if (developerDirs) {
+                for (let dir of developerDirs) {
+                    safeMkdir(dir + '/node_modules');
+                    safeSymlinkSync(path.dirname(require.resolve('..')), dir + '/node_modules/thingpedia');
+                    safeSymlinkSync(path.dirname(require.resolve('thingtalk')), dir + '/node_modules/thingtalk');
+                }
             }
         }
     }
@@ -124,6 +125,16 @@ module.exports = class ModuleDownloader {
         return this._moduleRequests.get(id);
     }
 
+    _getDeveloperDirs() {
+        const prefs = this.platform.getSharedPreferences();
+        let developerDirs = prefs.get('developer-dir');
+        if (!developerDirs)
+            return undefined;
+        if (!Array.isArray(developerDirs))
+            developerDirs = [developerDirs];
+        return developerDirs;
+    }
+
     async _loadClassCode(id, canUseCache) {
         if (!this._platform.hasCapability('code-download'))
             return Promise.reject(new Error('Code download is not allowed on this platform'));
@@ -133,12 +144,13 @@ module.exports = class ModuleDownloader {
 
         // if there is a developer directory, and it contains a manifest for the current device, load
         // it directly, bypassing the cache logic
-        const prefs = this._platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (developerDir && this._client._getLocalDeviceManifest) {
-            const localPath = path.resolve(developerDir, id, 'manifest.tt');
-            if (await util.promisify(fs.exists)(localPath))
-                return (await this._client._getLocalDeviceManifest(localPath, id)).prettyprint();
+        const developerDirs = this._getDeveloperDirs();
+        if (developerDirs && this._client._getLocalDeviceManifest) {
+            for (let dir of developerDirs) {
+                const localPath = path.resolve(dir, id, 'manifest.tt');
+                if (await util.promisify(fs.exists)(localPath))
+                    return (await this._client._getLocalDeviceManifest(localPath, id)).prettyprint();
+            }
         }
 
         const manifestTmpPath = this._cacheDir + '/' + id + '.tt.tmp';

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -92,42 +92,63 @@ class HttpClient extends ClientBase {
         return ourParsed.classes[0];
     }
 
-    async getDeviceCode(id) {
+    _getDeveloperDirs() {
         const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
+        let developerDirs = prefs.get('developer-dir');
+        if (!developerDirs)
+            return undefined;
+        if (!Array.isArray(developerDirs))
+            developerDirs = [developerDirs];
+        return developerDirs;
+    }
 
-        if (developerDir) {
-            const localPath = path.resolve(developerDir, id, 'manifest.tt');
-            if (await util.promisify(fs.exists)(localPath))
-                return (await this._getLocalDeviceManifest(localPath, id)).prettyprint();
+    async getDeviceCode(id) {
+        const developerDirs = this._getDeveloperDirs();
+
+        if (developerDirs) {
+            for (let dir of developerDirs) {
+                const localPath = path.resolve(dir, id, 'manifest.tt');
+                if (await util.promisify(fs.exists)(localPath))
+                    return (await this._getLocalDeviceManifest(localPath, id)).prettyprint();
+            }
         }
 
         return this._getDeviceCodeHttp(id);
     }
 
     async getModuleLocation(id) {
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (developerDir && await util.promisify(fs.exists)(path.resolve(developerDir, id)))
-            return 'file://' + path.resolve(developerDir, id);
-        else
-            return this._getModuleLocationHttp(id);
+        const developerDirs = this._getDeveloperDirs();
+
+        if (developerDirs) {
+            for (let dir of developerDirs) {
+                if (await util.promisify(fs.exists)(path.resolve(dir, id)))
+                    return 'file://' + path.resolve(dir, id);
+            }
+        }
+
+        return this._getModuleLocationHttp(id);
     }
 
     async getSchemas(kinds, withMetadata) {
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (!developerDir)
+        const developerDirs = this._getDeveloperDirs();
+
+        if (!developerDirs)
             return this._getSchemasHttp(kinds, withMetadata);
 
         const forward = [];
         const handled = [];
 
         for (let kind of kinds) {
-            const localPath = path.resolve(developerDir, kind, 'manifest.tt');
-            if (await util.promisify(fs.exists)(localPath))
-                handled.push(await this._getLocalDeviceManifest(localPath, kind));
-            else
+            let ok = false;
+            for (let dir of developerDirs) {
+                const localPath = path.resolve(dir, kind, 'manifest.tt');
+                if (await util.promisify(fs.exists)(localPath)) {
+                    handled.push(await this._getLocalDeviceManifest(localPath, kind));
+                    ok = true;
+                    break;
+                }
+            }
+            if (!ok)
                 forward.push(kind);
         }
 
@@ -149,18 +170,25 @@ class HttpClient extends ClientBase {
     }
 
     async getDeviceSetup(kinds) {
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (!developerDir)
+        const developerDirs = this._getDeveloperDirs();
+
+        if (!developerDirs)
             return this._getDeviceSetupHttp(kinds);
 
         const forward = [];
         const handled = {};
+
         for (let kind of kinds) {
-            const localPath = path.resolve(developerDir, kind, 'manifest.tt');
-            if (await util.promisify(fs.exists)(localPath))
-                handled[kind] = await this._getLocalFactory(localPath, kind);
-            else
+            let ok = false;
+            for (let dir of developerDirs) {
+                const localPath = path.resolve(dir, kind, 'manifest.tt');
+                if (await util.promisify(fs.exists)(localPath)) {
+                    handled[kind] = await this._getLocalFactory(localPath, kind);
+                    ok = true;
+                    break;
+                }
+            }
+            if (!ok)
                 forward.push(kind);
         }
 
@@ -307,18 +335,24 @@ class HttpClient extends ClientBase {
     }
 
     async getExamplesByKinds(kinds) {
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (!developerDir)
+        const developerDirs = this._getDeveloperDirs();
+
+        if (!developerDirs)
             return this._getExamplesByKinds(kinds);
 
         const forward = [];
         const handled = [];
         for (let kind of kinds) {
-            const localPath = path.resolve(developerDir, kind, 'dataset.tt');
-            if (await util.promisify(fs.exists)(localPath))
-                handled.push(await util.promisify(fs.readFile)(localPath, { encoding: 'utf8' }));
-            else
+            let ok = false;
+            for (let dir of developerDirs) {
+                const localPath = path.resolve(dir, kind, 'dataset.tt');
+                if (await util.promisify(fs.exists)(localPath)) {
+                    handled.push(await util.promisify(fs.readFile)(localPath, { encoding: 'utf8' }));
+                    ok = true;
+                    break;
+                }
+            }
+            if (!ok)
                 forward.push(kind);
         }
 
@@ -354,20 +388,7 @@ class HttpClient extends ClientBase {
     }
 
     async getAllEntityTypes() {
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (!developerDir)
-            return this._simpleRequest('/entities/all');
-
-        const entities = await this._simpleRequest('/entities/all');
-        for (let device of await util.promisify(fs.readdir)(developerDir)) {
-            const localPath = path.resolve(developerDir, device, 'entities.json');
-            if (await util.promisify(fs.exists)(localPath)) {
-                const local = JSON.parse(await util.promisify(fs.readFile)(localPath, { encoding: 'utf8' }));
-                entities.push(...local.data);
-            }
-        }
-        return entities;
+        return this._simpleRequest('/entities/all');
     }
 
     async getAllDeviceNames() {
@@ -385,19 +406,21 @@ class HttpClient extends ClientBase {
             });
         }
 
-        const prefs = this.platform.getSharedPreferences();
-        const developerDir = prefs.get('developer-dir');
-        if (!developerDir)
+        const developerDirs = this._getDeveloperDirs();
+
+        if (!developerDirs)
             return names;
 
-        for (let device of await util.promisify(fs.readdir)(developerDir)) {
-            const localPath = path.resolve(developerDir, device, 'manifest.tt');
-            if (await util.promisify(fs.exists)(localPath)) {
-                const classDef = (await this._getLocalDeviceManifest(localPath, device));
-                names.push({
-                    kind: classDef.kind,
-                    kind_canonical: classDef.metadata.canonical
-                });
+        for (let dir of developerDirs) {
+            for (let device of await util.promisify(fs.readdir)(dir)) {
+                const localPath = path.resolve(dir, device, 'dataset.tt');
+                if (await util.promisify(fs.exists)(localPath)) {
+                    const classDef = (await this._getLocalDeviceManifest(localPath, device));
+                    names.push({
+                        kind: classDef.kind,
+                        kind_canonical: classDef.metadata.canonical
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
If "developer-dir" is set to an array, check for a device in
each directory. This is needed to support the new layout in
thingpedia-common-devices