### PR TITLE
platform: add a method to specify the OAuth redirect origin

### DIFF
--- a/lib/base_platform.js
+++ b/lib/base_platform.js
@@ -149,11 +149,24 @@ class BasePlatform {
         throw new Error('not implemented');
     }
 
-    /* istanbul ignore next */
     /**
      * Retrieve the HTTP origin to use for OAuth redirects.
      *
+     * This defaults to {@link BasePlatform#getOrigin} but can be overridden
+     * by subclasses that need different origins for HTTP and OAuth.
+     *
      * @return {string} an HTTP origin (protocol, hostname and port)
+     */
+    getOAuthRedirect() {
+        return this.getOrigin();
+    }
+
+    /* istanbul ignore next */
+    /**
+     * Retrieve the HTTP origin to use to refer to the current platform.
+     *
+     * @return {string} an HTTP origin (protocol, hostname and port)
+     */
     getOrigin() {
         throw new Error('not implemented');
     }

--- a/lib/helpers/oauth2.js
+++ b/lib/helpers/oauth2.js
@@ -59,7 +59,7 @@ module.exports = function OAuth2Helper(params) {
                                       params.get_access_token,
                                       customHeaders);
         auth.useAuthorizationHeaderforGET(true);
-        const origin = engine.platform.getOrigin();
+        const origin = engine.platform.getOAuthRedirect();
         let redirect_uri;
         if (params.redirect_uri)
             redirect_uri = params.redirect_uri;


### PR DESCRIPTION
On the server platform, where we use the OAuth proxy through
almond-cloud, we need to separate the OAuth redirect from
the regular origin.