### PR TITLE
Migrate to ThingTalk 2.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+test/device-classes/com.xkcd

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,10 +18,15 @@ rules:
   no-lonely-if: off
   arrow-body-style: off
   require-yield: off
+  '@typescript-eslint/no-non-null-assertion': off
+  '@typescript-eslint/no-explicit-any': off
+  # namespaces are useful to add static methods to enums and to implement
+  # nested classes
+  '@typescript-eslint/no-namespace': off
 
   # temporary until migration is complete
   '@typescript-eslint/no-this-alias': off
-  '@typescript-eslint/no-explicit-any': off
+  '@typescript-eslint/explicit-module-boundary-types': off
 
   # correctness checks
   strict:

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -97,7 +97,7 @@ export default class ModuleDownloader {
                 let file = path.resolve(this._cacheDir, name);
                 if (name.endsWith('.tt')) {
                     const buffer = await util.promisify(fs.readFile)(file);
-                    const parsed = ThingTalk.Grammar.parse(buffer.toString('utf8')).classes[0];
+                    const parsed = ThingTalk.Syntax.parse(buffer.toString('utf8')).classes[0];
 
                     return ({ name: parsed.kind,
                               version: parsed.annotations.version.toJS() });
@@ -204,9 +204,9 @@ export default class ModuleDownloader {
 
     async loadClass(id, canUseCache) {
         const classCode = await this._loadClassCode(id, canUseCache);
-        const parsed = await ThingTalk.Grammar.parseAndTypecheck(classCode, this._schemas);
+        const parsed = await ThingTalk.Syntax.parse(classCode).typecheck(this._schemas);
 
-        assert(parsed.isMeta && parsed.classes.length === 1);
+        assert(parsed.isLibrary && parsed.classes.length === 1);
         const classdef = parsed.classes[0];
         this._schemas.injectClass(classdef);
         return classdef;

--- a/lib/file_thingpedia_client.ts
+++ b/lib/file_thingpedia_client.ts
@@ -108,7 +108,14 @@ export default class FileClient extends BaseClient {
 
         if (this._datasetfilename) {
             this._dataset = await util.promisify(fs.readFile)(this._datasetfilename, { encoding: 'utf8' });
-            const parsed = await ThingTalk.Syntax.parse(this._dataset);
+            let parsed;
+            try {
+                parsed = await ThingTalk.Syntax.parse(this._dataset);
+            } catch(e) {
+                if (e.name !== 'SyntaxError')
+                    throw e;
+                parsed = await ThingTalk.Syntax.parse(this._dataset, ThingTalk.Syntax.SyntaxType.Legacy);
+            }
             assert(parsed instanceof Ast.Library);
 
             for (const dataset of parsed.datasets) {

--- a/lib/file_thingpedia_client.ts
+++ b/lib/file_thingpedia_client.ts
@@ -107,7 +107,7 @@ export default class FileClient extends BaseClient {
 
         if (this._datasetfilename) {
             this._dataset = await util.promisify(fs.readFile)(this._datasetfilename, { encoding: 'utf8' });
-            const parsed = await ThingTalk.Grammar.parse(this._dataset);
+            const parsed = await ThingTalk.Syntax.parse(this._dataset);
             assert(parsed instanceof Ast.Library);
 
             for (const dataset of parsed.datasets) {
@@ -148,7 +148,7 @@ export default class FileClient extends BaseClient {
         // we don't have the full class, so we just return the meta info
         await this._ensureLoaded();
 
-        const parsed = ThingTalk.Grammar.parse(this._devices!);
+        const parsed = ThingTalk.Syntax.parse(this._devices!);
         assert(parsed instanceof Ast.Library);
         for (const classDef of parsed.classes) {
             if (classDef.kind === kind)
@@ -172,8 +172,8 @@ export default class FileClient extends BaseClient {
                 examples = examples.concat(this._examples[device]);
         }
 
-        const name = `@org.thingpedia.dynamic.by_kinds.${kinds.join('__')}`;
-        const dataset = new Ast.Dataset(null, name, 'en', examples, {});
+        const name = `org.thingpedia.dynamic.by_kinds.${kinds.join('__')}`;
+        const dataset = new Ast.Dataset(null, name, examples);
         const library = new Ast.Input.Library(null, [], [dataset]);
         return library.prettyprint();
     }
@@ -181,7 +181,7 @@ export default class FileClient extends BaseClient {
     async getAllDeviceNames() : Promise<DeviceNameRecord[]> {
         await this._ensureLoaded();
 
-        const parsed = ThingTalk.Grammar.parse(this._devices!);
+        const parsed = ThingTalk.Syntax.parse(this._devices!);
         assert(parsed instanceof Ast.Library);
         const names = [];
         for (const classDef of parsed.classes) {

--- a/lib/http_client.ts
+++ b/lib/http_client.ts
@@ -90,7 +90,7 @@ export default class HttpClient extends ClientBase {
 
     private async _getLocalDeviceManifest(manifestPath : string, deviceKind : string) {
         const ourMetadata = (await util.promisify(fs.readFile)(manifestPath)).toString();
-        const ourParsed = ThingTalk.Grammar.parse(ourMetadata);
+        const ourParsed = ThingTalk.Syntax.parse(ourMetadata);
         assert(ourParsed instanceof Ast.Library);
         ourParsed.classes[0].annotations.version = new Ast.Value.Number(-1);
 
@@ -106,7 +106,7 @@ export default class HttpClient extends ClientBase {
                 // for that reason we fetch the metadata for thingpedia as well,
                 // and fill in any missing parameter
                 const officialMetadata = await this._getDeviceCodeHttp(deviceKind);
-                const officialParsed = ThingTalk.Grammar.parse(officialMetadata);
+                const officialParsed = ThingTalk.Syntax.parse(officialMetadata);
                 assert(officialParsed instanceof Ast.Library);
 
                 ourConfig.in_params = ourConfig.in_params.filter((ip) => !ip.value.isUndefined);
@@ -440,7 +440,7 @@ export default class HttpClient extends ClientBase {
         if (!snapshot)
             snapshot = await this._cacheSnapshot();
 
-        const parsed = ThingTalk.Grammar.parse(snapshot);
+        const parsed = ThingTalk.Syntax.parse(snapshot);
         assert(parsed instanceof Ast.Library);
         for (const classDef of parsed.classes) {
             names.push({

--- a/lib/loaders/base_generic.js
+++ b/lib/loaders/base_generic.js
@@ -40,6 +40,7 @@ export default class BaseGenericModule {
         else if (this._config.module === 'org.thingpedia.config.oauth2')
             params = Utils.findMixinArg(this._config.mixin, 'profile') || [];
 
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this._loaded = class GenericDevice extends BaseDevice {
             constructor(engine, state) {
                 super(engine, state);

--- a/lib/loaders/unsupported_builtin.js
+++ b/lib/loaders/unsupported_builtin.js
@@ -32,6 +32,7 @@ export default class UnsupportedBuiltinModule {
         this._id = id;
         this._manifest = manifest;
 
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this._loaded = class UnsupportedDevice extends BaseDevice {
             constructor(engine, state) {
                 super(engine, state);

--- a/package-lock.json
+++ b/package-lock.json
@@ -393,6 +393,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
+    },
     "@types/xml2js": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.7.tgz",
@@ -868,6 +874,12 @@
         "minimist": "^1.2.5",
         "request": "^2.88.2"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -2657,10 +2669,11 @@
       "dev": true
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#5162f6b447f9286ff8caeeb21c01220b9477cccc",
-      "from": "github:stanford-oval/thingtalk#wip/typescript5",
+      "version": "github:stanford-oval/thingtalk#62710e73cd8e3336f45a3647f635a6ccbb35408f",
+      "from": "github:stanford-oval/thingtalk#next",
       "dev": true,
       "requires": {
+        "@types/semver": "^7.3.4",
         "byline": "^5.0.0",
         "consumer-queue": "^1.0.0",
         "semver": "^7.3.2",
@@ -2709,12 +2722,13 @@
       }
     },
     "ts-node": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
-      "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.0.tgz",
+      "integrity": "sha512-0yqcL4sgruCvM+w64LiAfNJo6+lHfCYc5Ajj4yiLNkJ9oZ2HWaa+Kso7htYOOxVQ7+csAjdUjffOe9PIqC4pMg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -501,12 +501,6 @@
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
       "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
     },
-    "adt": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/adt/-/adt-0.7.2.tgz",
-      "integrity": "sha1-gku3Jf42MsjDXsJJhd9hD5fZgkQ=",
-      "dev": true
-    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2663,28 +2657,16 @@
       "dev": true
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#4bb276d48bdc819ecf6fbbda950f208aa94d61aa",
-      "from": "github:stanford-oval/thingtalk#next",
+      "version": "github:stanford-oval/thingtalk#eae6c202ff21e06d3275ffcf9311f26ceff25f3d",
+      "from": "github:stanford-oval/thingtalk#wip/typescript5",
       "dev": true,
       "requires": {
-        "adt": "~0.7.2",
         "byline": "^5.0.0",
         "consumer-queue": "^1.0.0",
         "semver": "^7.3.2",
-        "smtlib": "^0.1.1",
+        "smtlib": "^1.0.0",
         "string-interp": "^0.3.1",
         "thingtalk-units": "^0.2.0"
-      },
-      "dependencies": {
-        "smtlib": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/smtlib/-/smtlib-0.1.1.tgz",
-          "integrity": "sha1-eq5W8S0U4+Nw/8jRxcjk/gG66VA=",
-          "dev": true,
-          "requires": {
-            "byline": "^5.0.0"
-          }
-        }
       }
     },
     "thingtalk-units": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,9 +363,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
     },
     "@types/node-gettext": {
       "version": "3.0.1",
@@ -394,21 +394,21 @@
       }
     },
     "@types/xml2js": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
-      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.7.tgz",
+      "integrity": "sha512-f5VOKSMEE0O+/L54FHwA/a7vcx9mHeSDM71844yHCOhh8Cin2xQa0UFw0b7Vc5hoZ3Ih6ZHaDobjfLih4tWPNw==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.6.1.tgz",
-      "integrity": "sha512-SNZyflefTMK2JyrPfFFzzoy2asLmZvZJ6+/L5cIqg4HfKGiW2Gr1Go1OyEVqne/U4QwmoasuMwppoBHWBWF2nA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.9.0.tgz",
+      "integrity": "sha512-WrVzGMzzCrgrpnQMQm4Tnf+dk+wdl/YbgIgd5hKGa2P+lnJ2MON+nQnbwgbxtN9QDLi8HO+JAq0/krMnjQK6Cw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.6.1",
-        "@typescript-eslint/scope-manager": "4.6.1",
+        "@typescript-eslint/experimental-utils": "4.9.0",
+        "@typescript-eslint/scope-manager": "4.9.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -417,55 +417,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.6.1.tgz",
-      "integrity": "sha512-qyPqCFWlHZXkEBoV56UxHSoXW2qnTr4JrWVXOh3soBP3q0o7p4pUEMfInDwIa0dB/ypdtm7gLOS0hg0a73ijfg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.0.tgz",
+      "integrity": "sha512-0p8GnDWB3R2oGhmRXlEnCvYOtaBCijtA5uBfH5GxQKsukdSQyI4opC4NGTUb88CagsoNQ4rb/hId2JuMbzWKFQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.6.1",
-        "@typescript-eslint/types": "4.6.1",
-        "@typescript-eslint/typescript-estree": "4.6.1",
+        "@typescript-eslint/scope-manager": "4.9.0",
+        "@typescript-eslint/types": "4.9.0",
+        "@typescript-eslint/typescript-estree": "4.9.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.6.1.tgz",
-      "integrity": "sha512-lScKRPt1wM9UwyKkGKyQDqf0bh6jm8DQ5iN37urRIXDm16GEv+HGEmum2Fc423xlk5NUOkOpfTnKZc/tqKZkDQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.9.0.tgz",
+      "integrity": "sha512-QRSDAV8tGZoQye/ogp28ypb8qpsZPV6FOLD+tbN4ohKUWHD2n/u0Q2tIBnCsGwQCiD94RdtLkcqpdK4vKcLCCw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.6.1",
-        "@typescript-eslint/types": "4.6.1",
-        "@typescript-eslint/typescript-estree": "4.6.1",
+        "@typescript-eslint/scope-manager": "4.9.0",
+        "@typescript-eslint/types": "4.9.0",
+        "@typescript-eslint/typescript-estree": "4.9.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.6.1.tgz",
-      "integrity": "sha512-f95+80r6VdINYscJY1KDUEDcxZ3prAWHulL4qRDfNVD0I5QAVSGqFkwHERDoLYJJWmEAkUMdQVvx7/c2Hp+Bjg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.9.0.tgz",
+      "integrity": "sha512-q/81jtmcDtMRE+nfFt5pWqO0R41k46gpVLnuefqVOXl4QV1GdQoBWfk5REcipoJNQH9+F5l+dwa9Li5fbALjzg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.6.1",
-        "@typescript-eslint/visitor-keys": "4.6.1"
+        "@typescript-eslint/types": "4.9.0",
+        "@typescript-eslint/visitor-keys": "4.9.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.6.1.tgz",
-      "integrity": "sha512-k2ZCHhJ96YZyPIsykickez+OMHkz06xppVLfJ+DY90i532/Cx2Z+HiRMH8YZQo7a4zVd/TwNBuRCdXlGK4yo8w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.6.1.tgz",
-      "integrity": "sha512-/J/kxiyjQQKqEr5kuKLNQ1Finpfb8gf/NpbwqFFYEBjxOsZ621r9AqwS9UDRA1Rrr/eneX/YsbPAIhU2rFLjXQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.0.tgz",
+      "integrity": "sha512-rmDR++PGrIyQzAtt3pPcmKWLr7MA+u/Cmq9b/rON3//t5WofNR4m/Ybft2vOLj0WtUzjn018ekHjTsnIyBsQug==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.6.1",
-        "@typescript-eslint/visitor-keys": "4.6.1",
+        "@typescript-eslint/types": "4.9.0",
+        "@typescript-eslint/visitor-keys": "4.9.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -475,12 +475,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.6.1.tgz",
-      "integrity": "sha512-owABze4toX7QXwOLT3/D5a8NecZEjEWU1srqxENTfqsY3bwVnl3YYbOh6s1rp2wQKO9RTHFGjKes08FgE7SVMw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.0.tgz",
+      "integrity": "sha512-sV45zfdRqQo1A97pOSx3fsjR+3blmwtdCt8LDrXgCX36v4Vmz4KHrhpV6Fo2cRdXmyumxx11AHw0pNJqCNpDyg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.6.1",
+        "@typescript-eslint/types": "4.9.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -995,9 +995,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
-      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz",
+      "integrity": "sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2657,14 +2657,14 @@
       "dev": true
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#d0a20f0915da5361c3a207235156e8e5e41da5f1",
-      "from": "github:stanford-oval/thingtalk#next",
+      "version": "github:stanford-oval/thingtalk#5162f6b447f9286ff8caeeb21c01220b9477cccc",
+      "from": "github:stanford-oval/thingtalk#wip/typescript5",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
         "consumer-queue": "^1.0.0",
         "semver": "^7.3.2",
-        "smtlib": "^0.1.1",
+        "smtlib": "^1.0.0",
         "string-interp": "^0.3.1",
         "thingtalk-units": "^0.2.0"
       }
@@ -2801,9 +2801,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "xml2js": "^0.4.17"
   },
   "peerDependencies": {
-    "thingtalk": "github:stanford-oval/thingtalk#wip/typescript5"
+    "thingtalk": "github:stanford-oval/thingtalk#next"
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./lib ./test",
@@ -51,9 +51,9 @@
     "nyc": "^15.0.0",
     "pegjs": "^0.10.0",
     "source-map-support": "^0.5.19",
-    "thingtalk": "github:stanford-oval/thingtalk#wip/typescript5",
+    "thingtalk": "github:stanford-oval/thingtalk#next",
     "tough-cookie": "^4.0.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^9.1.0",
     "typedoc": "^0.19.2",
     "typescript": "^4.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "dependencies": {
     "@types/feedparser": "^2.2.3",
     "@types/ip": "^1.1.0",
-    "@types/node": "^14.14.6",
+    "@types/node": "^14.14.10",
     "@types/node-gettext": "^3.0.1",
     "@types/oauth": "^0.9.1",
     "@types/qs": "^6.9.5",
-    "@types/xml2js": "^0.4.5",
+    "@types/xml2js": "^0.4.7",
     "feedparser": "^2.2.9",
     "gettext-parser": "^4.0.2",
     "ip": "^1.1.0",
@@ -43,10 +43,10 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@typescript-eslint/eslint-plugin": "^4.6.1",
-    "@typescript-eslint/parser": "^4.6.1",
+    "@typescript-eslint/eslint-plugin": "^4.9.0",
+    "@typescript-eslint/parser": "^4.9.0",
     "coveralls": "^3.0.0",
-    "eslint": "^7.12.1",
+    "eslint": "^7.14.0",
     "node-gettext": "^3.0.0",
     "nyc": "^15.0.0",
     "pegjs": "^0.10.0",
@@ -55,7 +55,7 @@
     "tough-cookie": "^4.0.0",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.2",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.2"
   },
   "nyc": {
     "extends": "@istanbuljs/nyc-config-typescript"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "xml2js": "^0.4.17"
   },
   "peerDependencies": {
-    "thingtalk": "github:stanford-oval/thingtalk#next"
+    "thingtalk": "github:stanford-oval/thingtalk#wip/typescript5"
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./lib ./test",
@@ -51,7 +51,7 @@
     "nyc": "^15.0.0",
     "pegjs": "^0.10.0",
     "source-map-support": "^0.5.19",
-    "thingtalk": "github:stanford-oval/thingtalk#next",
+    "thingtalk": "github:stanford-oval/thingtalk#wip/typescript5",
     "tough-cookie": "^4.0.0",
     "ts-node": "^9.0.0",
     "typedoc": "^0.19.2",

--- a/test/data/dataset.tt
+++ b/test/data/dataset.tt
@@ -1,4 +1,5 @@
-dataset @org.thingpedia.everything language "en" {
+dataset @org.thingpedia.everything
+#[language="en"] {
     program (p_hashtag : Entity(tt:hashtag)) := monitor(@com.twitter.home_timeline()), contains(hashtags, p_hashtag) => @com.twitter.retweet(tweet_id=tweet_id)
     #[id=-1]
     #_[utterances=["autoretweet tweets with $p_hashtag", "autoretweet $p_hashtag"]]
@@ -24,12 +25,12 @@ dataset @org.thingpedia.everything language "en" {
     #_[utterances=["images matching ${p_query}", "${p_query:const} images"]]
     #_[preprocessed=["images matching ${p_query}", "${p_query:const} images"]];
 
-    query (p_query : String) := sort title asc of @com.bing.image_search(query=p_query)
+    query (p_query : String) := sort(title asc of @com.bing.image_search(query=p_query))
     #[id=3]
     #_[utterances=["images matching ${p_query} sorted by title", "${p_query:const} images sorted by title"]]
     #_[preprocessed=["images matching ${p_query} sorted by title", "${p_query:const} images sorted by title"]];
 
-    query (p_query : String) := aggregate count of @com.bing.image_search(query=p_query)
+    query (p_query : String) := count(@com.bing.image_search(query=p_query))
     #[id=4]
     #_[utterances=["the number of images that match ${p_query}", "the count of images that match ${p_query:const}"]]
     #_[preprocessed=["the number of images that match ${p_query}", "the count of images that match ${p_query:const}"]];

--- a/test/data/thingpedia.tt
+++ b/test/data/thingpedia.tt
@@ -509,7 +509,7 @@ class @com.yahoo.finance
 #_[canonical="yahoo finance"] {
   monitorable query get_stock_div(in req stock_id: Entity(tt:stock_id) #_[prompt="What company's stock do you want to watch? Use the 4 letter ID, like GOOG, AAPL or MSFT"] #_[canonical="stock id"],
                                   out company_name: String #_[canonical="company name"],
-                                  out yield: Number #_[canonical="yield"],
+                                  out yield_: Number #_[canonical="yield"],
                                   out value: Currency #_[canonical="value"],
                                   out pay_date: Date #_[canonical="pay date"],
                                   out ex_dividend_date: Date #_[canonical="ex dividend date"])

--- a/test/device-classes/org.httpbin.basicauth.tt
+++ b/test/device-classes/org.httpbin.basicauth.tt
@@ -1,7 +1,7 @@
 class @org.httpbin.basicauth
 #[version=1] {
   import loader from @org.thingpedia.generic_rest.v1();
-  import config from @org.thingpedia.config.basic_auth(extra_params=makeArgMap(username:String,password:String));
+  import config from @org.thingpedia.config.basic_auth(extra_params=new ArgMap(username:String,password:String));
 
   query get(in req input: String,
             out authenticated: Boolean,

--- a/test/device-classes/org.httpbin.form.tt
+++ b/test/device-classes/org.httpbin.form.tt
@@ -1,6 +1,6 @@
 class @org.httpbin.form
 #[version=1] {
   import loader from @org.thingpedia.generic_rest.v1();
-  import config from @org.thingpedia.config.form(params=makeArgMap(foo: String));
+  import config from @org.thingpedia.config.form(params=new ArgMap(foo: String));
 }
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -226,7 +226,7 @@ class State {
 }
 
 function toClassDef(classCode) {
-    return ThingTalk.Grammar.parse(classCode).classes[0];
+    return ThingTalk.Syntax.parse(classCode).classes[0];
 }
 
 export {

--- a/test/po/extract-translatable-annotations.js
+++ b/test/po/extract-translatable-annotations.js
@@ -52,7 +52,7 @@ function extract(key, str) {
 
 async function main() {
     const code = (await util.promisify(fs.readFile)(process.argv[2])).toString();
-    const parsed = ThingTalk.Grammar.parse(code);
+    const parsed = ThingTalk.Syntax.parse(code);
 
     for (let _class of parsed.classes) {
         for (let key in _class.metadata)

--- a/test/test_builtin.js
+++ b/test/test_builtin.js
@@ -34,6 +34,8 @@ const Builtins = {
 
             query get(out something : String);
         }`,
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         module: class FooBuiltin extends BaseDevice {
             constructor(engine, state) {
                 super(engine, state);
@@ -54,6 +56,8 @@ const Builtins = {
             import loader from @org.thingpedia.builtin();
             import config from @org.thingpedia.config.none();
         }`,
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         module: class CollectionBuiltin extends BaseDevice {
             constructor(engine, state) {
                 super(engine, state);
@@ -71,6 +75,8 @@ const Builtins = {
 
             query bla(out something : String);
         }`,
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         module: class SubdeviceBuiltin extends BaseDevice {
             constructor(engine, state) {
                 super(engine, state);

--- a/test/test_device_factories.js
+++ b/test/test_device_factories.js
@@ -53,7 +53,7 @@ const TEST_CASES = [
 
     [`class @com.bodytrace.scale {
         import loader from @org.thingpedia.v2();
-        import config from @org.thingpedia.config.basic_auth(extra_params=makeArgMap(serial_number : String));
+        import config from @org.thingpedia.config.basic_auth(extra_params=new ArgMap(serial_number : String));
     }`, {
         name: "BodyTrace Scale",
         category: 'physical',
@@ -88,7 +88,7 @@ const TEST_CASES = [
 
     [`class @org.thingpedia.rss {
         import loader from @org.thingpedia.rss();
-        import config from @org.thingpedia.config.form(params=makeArgMap(url : Entity(tt:url)));
+        import config from @org.thingpedia.config.form(params=new ArgMap(url : Entity(tt:url)));
     }`, {
         primary_kind: "org.thingpedia.rss",
         name: "RSS Feed",
@@ -162,7 +162,7 @@ async function testCase(i) {
     console.log(`Test Case #${i+1}`);
     const [classCode, device, expectedFactory] = TEST_CASES[i];
 
-    const classDef = ThingTalk.Grammar.parse(classCode).classes[0];
+    const classDef = ThingTalk.Syntax.parse(classCode).classes[0];
     const generatedFactory = DeviceFactoryUtils.makeDeviceFactory(classDef, device);
 
     try {

--- a/test/test_discovery_services.js
+++ b/test/test_discovery_services.js
@@ -53,7 +53,7 @@ async function testCase(i) {
     console.log(`Test Case #${i+1}`);
     const [classCode, expectedServices] = TEST_CASES[i];
 
-    const classDef = ThingTalk.Grammar.parse(classCode).classes[0];
+    const classDef = ThingTalk.Syntax.parse(classCode).classes[0];
     const generatedServices = DeviceFactoryUtils.getDiscoveryServices(classDef);
 
     try {

--- a/test/test_file_client.js
+++ b/test/test_file_client.js
@@ -38,7 +38,7 @@ const _fileClient = new FileClient({
 const _schemaRetriever = new ThingTalk.SchemaRetriever(_fileClient, null, true);
 
 async function checkValidManifest(manifest, moduleType) {
-    const parsed = await ThingTalk.Grammar.parseAndTypecheck(manifest, _schemaRetriever);
+    const parsed = await ThingTalk.Syntax.parse(manifest).typecheck(_schemaRetriever);
     assert(parsed.isLibrary);
     assert.strictEqual(parsed.classes.length, 1);
     assert.strictEqual(parsed.datasets.length, 0);
@@ -57,14 +57,14 @@ async function testGetDeviceCode() {
 
 async function testGetSchemas(withMetadata) {
     const bing = await _fileClient.getSchemas(['com.bing'], withMetadata);
-    const bingparsed = ThingTalk.Grammar.parse(bing);
-    assert(bingparsed.isMeta);
+    const bingparsed = ThingTalk.Syntax.parse(bing);
+    assert(bingparsed.isLibrary);
     assert(bingparsed.classes.length >= 1);
     assert(bingparsed.classes.find((c) => c.kind === 'com.bing'));
 
     const multiple = await _fileClient.getSchemas(['com.bing', 'com.twitter'], withMetadata);
-    const mparsed = ThingTalk.Grammar.parse(multiple);
-    assert(mparsed.isMeta);
+    const mparsed = ThingTalk.Syntax.parse(multiple);
+    assert(mparsed.isLibrary);
     assert(mparsed.classes.length >= 2);
     assert(mparsed.classes.find((c) => c.kind === 'com.bing'));
     assert(mparsed.classes.find((c) => c.kind === 'com.twitter'));
@@ -114,7 +114,7 @@ function arrayEqual(a1, a2) {
 }
 
 async function testGetExamples() {
-    const all = ThingTalk.Grammar.parse(await _fileClient.getAllExamples());
+    const all = ThingTalk.Syntax.parse(await _fileClient.getAllExamples());
     assert(all.isLibrary);
     assert.strictEqual(all.classes.length, 0);
     assert.strictEqual(all.datasets.length, 1);
@@ -127,7 +127,7 @@ async function testGetExamples() {
         ex.preprocessed.forEach((p) => assertNonEmptyString(p));
     }
 
-    const bing = ThingTalk.Grammar.parse(await _fileClient.getExamplesByKinds(['com.bing', 'com.google']));
+    const bing = ThingTalk.Syntax.parse(await _fileClient.getExamplesByKinds(['com.bing', 'com.google']));
     assert(bing.isLibrary);
     assert.strictEqual(bing.classes.length, 0);
     assert.strictEqual(bing.datasets.length, 1);

--- a/test/test_http_client.js
+++ b/test/test_http_client.js
@@ -78,8 +78,8 @@ const _developerHttpClient = new HttpClient(_mockDeveloperPlatform, THINGPEDIA_U
 //const _developerSchemaRetriever = new ThingTalk.SchemaRetriever(_developerHttpClient, null, true);
 
 async function checkValidManifest(manifest, moduleType) {
-    const parsed = await ThingTalk.Grammar.parseAndTypecheck(manifest, _schemaRetriever);
-    assert(parsed.isMeta);
+    const parsed = await ThingTalk.Syntax.parse(manifest).typecheck(_schemaRetriever);
+    assert(parsed.isLibrary);
     assert.strictEqual(parsed.classes.length, 1);
     assert.strictEqual(parsed.datasets.length, 0);
 
@@ -130,14 +130,14 @@ async function testGetModuleLocation() {
 
 async function testGetSchemas(withMetadata) {
     const bing = await _httpClient.getSchemas(['com.bing'], withMetadata);
-    const bingparsed = ThingTalk.Grammar.parse(bing);
-    assert(bingparsed.isMeta);
+    const bingparsed = ThingTalk.Syntax.parse(bing);
+    assert(bingparsed.isLibrary);
     assert.strictEqual(bingparsed.classes.length, 1);
     assert.strictEqual(bingparsed.classes[0].kind, 'com.bing');
 
     const multiple = await _httpClient.getSchemas(['com.bing', 'com.twitter'], withMetadata);
-    const mparsed = ThingTalk.Grammar.parse(multiple);
-    assert(mparsed.isMeta);
+    const mparsed = ThingTalk.Syntax.parse(multiple);
+    assert(mparsed.isLibrary);
     assert.strictEqual(mparsed.classes.length, 2);
     assert.strictEqual(mparsed.classes[0].kind, 'com.bing');
     assert.strictEqual(mparsed.classes[1].kind, 'com.twitter');
@@ -148,8 +148,8 @@ async function testGetSchemas(withMetadata) {
     assert.deepStrictEqual(invisible, ``);
 
     const invisible2 = await _developerHttpClient.getSchemas(['org.thingpedia.builtin.test.invisible'], withMetadata);
-    const invparsed = ThingTalk.Grammar.parse(invisible2);
-    assert(invparsed.isMeta);
+    const invparsed = ThingTalk.Syntax.parse(invisible2);
+    assert(invparsed.isLibrary);
     assert.strictEqual(invparsed.classes.length, 1);
     assert.strictEqual(invparsed.classes[0].kind, 'org.thingpedia.builtin.test.invisible');
 
@@ -381,8 +381,8 @@ async function testGetExamples() {
         }
     }
 
-    const byKey = ThingTalk.Grammar.parse(await _httpClient.getExamplesByKey('twitter'));
-    assert(byKey.isMeta);
+    const byKey = ThingTalk.Syntax.parse(await _httpClient.getExamplesByKey('twitter'));
+    assert(byKey.isLibrary);
     assert.strictEqual(byKey.classes.length, 0);
     assert.strictEqual(byKey.datasets.length, 1);
 
@@ -394,8 +394,8 @@ async function testGetExamples() {
         ex.preprocessed.forEach((p) => assertNonEmptyString(p));
     }
 
-    const byKindsSingle = ThingTalk.Grammar.parse(await _httpClient.getExamplesByKinds(['com.twitter']));
-    assert(byKindsSingle.isMeta);
+    const byKindsSingle = ThingTalk.Syntax.parse(await _httpClient.getExamplesByKinds(['com.twitter']));
+    assert(byKindsSingle.isLibrary);
     assert.strictEqual(byKindsSingle.classes.length, 0);
     assert.strictEqual(byKindsSingle.datasets.length, 1);
 
@@ -408,8 +408,8 @@ async function testGetExamples() {
         checkKinds(ex.value, ['com.twitter']);
     }
 
-    const byKindsMultiple = ThingTalk.Grammar.parse(await _httpClient.getExamplesByKinds(['com.twitter', 'com.bing']));
-    assert(byKindsMultiple.isMeta);
+    const byKindsMultiple = ThingTalk.Syntax.parse(await _httpClient.getExamplesByKinds(['com.twitter', 'com.bing']));
+    assert(byKindsMultiple.isLibrary);
     assert.strictEqual(byKindsMultiple.classes.length, 0);
     assert.strictEqual(byKindsMultiple.datasets.length, 1);
 

--- a/test/test_i18n.js
+++ b/test/test_i18n.js
@@ -55,11 +55,12 @@ async function testBuiltin() {
 #_[description="Descrizione del Predefinito Traducibile"]
 #[version=0] {
   import loader from @org.thingpedia.builtin();
+
   import config from @org.thingpedia.config.builtin();
 
-  monitorable query elements(out something: String
+  monitorable query elements(out something : String
                              #_[canonical="qualcosa"],
-                             out author: Entity(tt:username)
+                             out author : Entity(tt:username)
                              #_[canonical={
                                npp=["autore"],
                                pvp=["scritto da"],
@@ -69,8 +70,7 @@ async function testBuiltin() {
   #_[canonical="elementi"]
   #[poll_interval=1ms]
   #[minimal_projection=[]];
-}
-`);
+}`);
 
     const _class = await module.getDeviceClass();
     const dev = new _class(engine, { kind: 'org.thingpedia.builtin.translatable' });

--- a/test/test_i18n.js
+++ b/test/test_i18n.js
@@ -32,6 +32,8 @@ import { MockPlatform, MockEngine } from './mock';
 const Builtins = {
     'org.thingpedia.builtin.translatable': {
         class: fs.readFileSync(path.resolve(path.dirname(module.filename), './device-classes/org.thingpedia.builtin.translatable.tt'), { encoding: 'utf8' }),
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         module: class TranslatableBuiltin extends BaseDevice {
             get_elements() {
                 return [];

--- a/test/test_unit.js
+++ b/test/test_unit.js
@@ -245,7 +245,7 @@ const PARSE_GENERIC_RESPONSE_TEST_CASES = [
 
 function testParseGenericResponse() {
     PARSE_GENERIC_RESPONSE_TEST_CASES.forEach(([classcode, response, expected], i) => {
-        const fndef = TT.Grammar.parse(classcode).classes[0].queries.test;
+        const fndef = TT.Syntax.parse(classcode).classes[0].queries.test;
 
         console.log('Test Case #' + (i+1));
         const generated = Utils.parseGenericResponse(response, fndef);


### PR DESCRIPTION
These are the small changes to adapt to the new version of
ThingTalk. The biggest change is that the Grammar module
is now called Syntax, and parseAndTypecheck does not exist.
The compat property "isMeta" is also gone, and the API of
Ast.Dataset changed a bit.

The rest is actual syntax changes in the test cases, and cosmetic
changes.