### PR TITLE
Import MemoryPreferences class

### DIFF
--- a/lib/helpers/index.ts
+++ b/lib/helpers/index.ts
@@ -38,6 +38,7 @@ import * as Xml from './xml';
 import RefCounted from './ref_counted';
 import * as ObjectSet from './object_set';
 import FilePreferences from './file_prefs';
+import MemoryPreferences from './memory_prefs';
 
 export {
     Content,
@@ -49,4 +50,5 @@ export {
     RefCounted,
     ObjectSet,
     FilePreferences,
+    MemoryPreferences,
 };

--- a/lib/helpers/memory_prefs.ts
+++ b/lib/helpers/memory_prefs.ts
@@ -1,0 +1,59 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Thingpedia
+//
+// Copyright 2019-2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import Preferences from '../prefs';
+
+/**
+ * An implementation of {@link Preferences} that is entirely backed by
+ * memory and not persistent anywhere.
+ */
+export default class MemoryPreferences extends Preferences {
+    private _prefs : Record<string, unknown>;
+
+    constructor() {
+        super();
+        this._prefs = {};
+    }
+
+    keys() : string[] {
+        return Object.keys(this._prefs);
+    }
+
+    get(name : string) : unknown {
+        return this._prefs[name];
+    }
+
+    set<T>(name : string, value : T) : T {
+        const changed = this._prefs[name] !== value;
+        this._prefs[name] = value;
+        if (changed)
+            this.emit('changed', name);
+        return value;
+    }
+
+    delete(name : string) : void {
+        delete this._prefs[name];
+        this.emit('changed', name);
+    }
+
+    changed(name : string|null = null) : void {
+        this.emit('changed', name);
+    }
+}


### PR DESCRIPTION
This is an implementation of Preferences backed by memory. It's
useful for testing and for certain command-line use cases.

I have copied it in enough places it's worth including it here.