### PR TITLE
Add new interfaces for 3rd party notification and command dispatch

### DIFF
--- a/lib/base_device.ts
+++ b/lib/base_device.ts
@@ -563,13 +563,13 @@ export interface DeviceMetadata {
     };
 }
 
-interface OAuth2Interface {
+export interface OAuth2Interface {
     accessToken : string;
     refreshToken ?: string;
     refreshCredentials() : Promise<void>;
 }
 
-interface NotificationInterface {
+export interface NotificationInterface {
     notify(data : {
         appId : string;
         icon : string|null;

--- a/lib/base_device.ts
+++ b/lib/base_device.ts
@@ -29,6 +29,7 @@ import type Messaging from './messaging';
 import type ConfigDelegate from './config_delegate';
 import type BaseEngine from './base_engine';
 import type BasePlatform from './base_platform';
+import DialogueHandler from './dialogue-handler';
 
 /**
  * The coarse grain classification of the currently running Almond platform.
@@ -588,7 +589,8 @@ export interface QueryInterfaceMap {
     'subdevices' : ObjectSet.Base<BaseDevice>;
     'messaging' : Messaging;
     'oauth2' : OAuth2Interface;
-    'notifications': NotificationInterface;
+    'notifications' : NotificationInterface;
+    'dialogue-handler' : DialogueHandler<any, any>;
     [key : string] : unknown;
 }
 

--- a/lib/base_device.ts
+++ b/lib/base_device.ts
@@ -568,10 +568,27 @@ interface OAuth2Interface {
     refreshCredentials() : Promise<void>;
 }
 
+interface NotificationInterface {
+    notify(data : {
+        appId : string;
+        icon : string|null;
+        raw : Record<string, unknown>;
+        type : string;
+        formatted : any[]
+    }) : Promise<void>;
+
+    notifyError(data : {
+        appId : string;
+        icon : string|null;
+        error : Error
+    }) : Promise<void>;
+}
+
 export interface QueryInterfaceMap {
     'subdevices' : ObjectSet.Base<BaseDevice>;
     'messaging' : Messaging;
     'oauth2' : OAuth2Interface;
+    'notifications': NotificationInterface;
     [key : string] : unknown;
 }
 

--- a/lib/capabilities.ts
+++ b/lib/capabilities.ts
@@ -203,6 +203,26 @@ export interface SoundEffectsApi {
     play(name : string) : Promise<void>;
 }
 
+export interface NotificationBackend {
+    readonly name : string;
+    readonly uniqueId : string;
+    readonly requiredSettings : Record<string, string>;
+
+    notify(data : {
+        appId : string;
+        icon : string|null;
+        raw : Record<string, unknown>;
+        type : string;
+        formatted : any[]
+    }, config ?: Record<string, string>) : Promise<void>;
+
+    notifyError(data : {
+        appId : string;
+        icon : string|null;
+        error : Error
+    }, config ?: Record<string, string>) : Promise<void>;
+}
+
 export interface CapabilityMap {
     'thingpedia-client' : BaseClient;
     'content-api' : ContentApi;
@@ -223,6 +243,7 @@ export interface CapabilityMap {
     'system-lock' : SystemLockApi;
     'audio-player' : AudioPlayerApi;
     'sound-effects' : SoundEffectsApi;
+    'notifications' : NotificationBackend[];
 
     [key : string] : unknown;
 }

--- a/lib/dialogue-handler.ts
+++ b/lib/dialogue-handler.ts
@@ -1,0 +1,169 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Thingpedia
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import { Type } from "thingtalk";
+
+import { FormattedObject } from "./format_objects";
+
+/**
+ * Interface for handling dialogues in a Thingpedia skill as raw sentences.
+ *
+ * This interface allows a Thingpedia device to override all parsing of commands
+ * into ThingTalk and handle raw utterances from the user.
+ * It is mainly useful for search engines and other question-answering systems.
+ */
+interface DialogueHandler<AnalysisType extends DialogueHandler.CommandAnalysisResult, StateType> {
+    /**
+     * The priority of this dialogue handler.
+     *
+     * At runtime, all configured devices that expose this interface will be queried
+     * in parallel for each command, and the devices with the highest priority that
+     * reports high confidence will be chosen to reply to the user.
+     */
+    priority : DialogueHandler.Priority;
+
+    /**
+     * Initialize this dialogue handler for a new conversation.
+     *
+     * The dialogue handler can optionally produce a reply to show to the user immediately.
+     * This can be a reply to a previous user command (if `initialState` is not undefined,
+     * so the conversation is being resumed), or a welcome messge if `showWelcome` is `true`.
+     *
+     * @param initialState the initial state, in case an existing conversation is resumed
+     * @param showWelcome whether to show a welcome message to the user
+     */
+    initialize(initialState : StateType|undefined, showWelcome : boolean) : Promise<DialogueHandler.ReplyResult|null>;
+    /**
+     * Retrieve the state of this dialogue handler.
+     *
+     * This method is called to serialize the dialogue handler to preserve the conversation.
+     * `StateType` must be a JSON serializable type.
+     */
+    getState() : StateType;
+    /**
+     * Reset the state of the dialogue handler.
+     *
+     * The dialogue handler should return to the normal state, dropping any conversational context.
+     */
+    reset() : void;
+
+    /**
+     * Analyze the given command, to decide whether the command can be handled by this dialogue handler or not.
+     *
+     * @param command the command from the user
+     */
+    analyzeCommand(command : string) : Promise<AnalysisType>;
+
+    /**
+     * Produce the reply to the given (analyzed) command.
+     *
+     * This method will only be called if the dialogue handler is chosen to reply, so it is safe to perform
+     * side effects in this method.
+     *
+     * @param command the analyzed command
+     */
+    getReply(command : AnalysisType) : Promise<DialogueHandler.ReplyResult>;
+}
+
+namespace DialogueHandler {
+
+/**
+ * The priority of this dialogue handler.
+ */
+export enum Priority {
+    /**
+     * Fallback, only used if no dialogue handler is available.
+     *
+     * Equivalent to "Sorry, I did not understand that."
+     */
+    FALLBACK,
+
+    /**
+     * Can take over if confident, or if no other dialogue handler is available.
+     */
+    SECONDARY,
+
+    /**
+     * Will always take over if confident or almost confident
+     */
+    PRIMARY,
+}
+
+/**
+ * How confident the dialogue handler is that it can handle a given command.
+ */
+export enum Confidence {
+    /**
+     * The dialogue handler is confident that the command is in-domain.
+     */
+    CONFIDENT_IN_DOMAIN_COMMAND,
+
+    /**
+     * The command is potentially in-domain, but the confidence is low.
+     */
+    NONCONFIDENT_IN_DOMAIN_COMMAND,
+
+    /**
+     * The command is definitely out-of-domain and this dialogue handler cannot reply to this command.
+     */
+    OUT_OF_DOMAIN_COMMAND,
+}
+
+/**
+ * The result of analyzing a command.
+ *
+ * A dialogue handler will produce a subclass of this object in its
+ * {@link DialogueHandler.analyzeCommand} method, including additional
+ * information specific to the dialogue handler.
+ */
+export interface CommandAnalysisResult {
+    /**
+     * How confident the dialogue handler is of the prediction.
+     */
+    confident : Confidence;
+
+    /**
+     * The utterance of the user.
+     */
+    utterance : string;
+    /**
+     * A ThingTalk representation of the current turn, if the dialogue handler is chosen.
+     *
+     * This is used exclusively in the conversation logs, and need not correspond to any
+     * executable ThingTalk form, but should be valid ThingTalk syntax.
+     */
+    user_target : string;
+}
+
+/**
+ * The reply generated by a dialogue handler.
+ */
+export interface ReplyResult {
+    messages : Array<string|FormattedObject>;
+    expecting : Type|null;
+
+    // used in the conversation logs
+    context : string;
+    agent_target : string;
+}
+
+}
+
+export default DialogueHandler;

--- a/lib/format_objects.ts
+++ b/lib/format_objects.ts
@@ -1,0 +1,73 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2019-2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+/**
+ * A plain text message.
+ */
+ export interface Text {
+    type : 'text';
+    text : string;
+}
+
+/**
+ * A rich deep link (also known as a card).
+ *
+ * An RDL is expected to be displayed as a clickable card with optional
+ * description and picture.
+ */
+ export interface RDL {
+    type : 'rdl';
+    callback ?: string;
+    webCallback : string;
+    displayTitle : string;
+    displayText ?: string;
+    pictureUrl ?: string;
+}
+
+/**
+ * A short notification sound from a predefined library.
+ */
+export interface SoundEffect {
+    type : 'sound';
+    name : string;
+    exclusive ?: boolean;
+}
+
+/**
+ * A picture, video, or music file.
+ */
+export interface Media {
+    type : 'picture'|'audio'|'video';
+    url : string;
+    alt ?: string;
+}
+
+/**
+ * A button that triggers a pre-parsed ThingTalk command.
+ */
+export interface Button {
+    type : 'button';
+    title : string;
+    json : string;
+}
+
+export type FormattedObject = (RDL | SoundEffect | Media | Text | Button) & {
+    toLocaleString(locale : string) : string;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,6 +27,8 @@ import BaseEngine from './base_engine';
 import BasePlatform, { UserProfile } from './base_platform';
 import * as DeviceConfigUtils from './device_factory_utils';
 import * as Capabilities from './capabilities';
+import DialogueHandler from './dialogue-handler';
+import * as FormatObjects from './format_objects';
 
 import * as ThingTalk from 'thingtalk';
 
@@ -130,6 +132,8 @@ export {
     Preferences,
     Capabilities,
     UserProfile,
+    DialogueHandler,
+    FormatObjects,
 
     // compatibility export
     ObjectSet,


### PR DESCRIPTION
The first commit moves over here the interfaces that were already defined in Genie (unsafely with a type assertion). These interfaces allow a user to receive notifications over email, sms, and potentially Slack or other services in the future, once those devices are enabled by the user.

The second commit deals with dispatching commands to skills directly, bypassing ThingTalk and the Genie dialogue state machine entirely. This is meant for question answering/web search, but can also be used to integrate 3rd party NLU if one wishes. 