### PR TITLE
Expand documentation of BaseDevice.ownerTier, BaseEngine.ownTier

### DIFF
--- a/lib/base_device.ts
+++ b/lib/base_device.ts
@@ -438,7 +438,6 @@ abstract class BaseDevice extends events.EventEmitter {
         return this.state;
     }
 
-    /* istanbul ignore next */
     /**
      * Start a device.
      *
@@ -449,7 +448,6 @@ abstract class BaseDevice extends events.EventEmitter {
         // nothing to do here, subclasses can override if they need to
     }
 
-    /* istanbul ignore next */
     /**
      * Stop a device.
      *
@@ -460,9 +458,23 @@ abstract class BaseDevice extends events.EventEmitter {
         // nothing to do here, subclasses can override if they need to
     }
 
-
-    // Obsolete, ignore
-    get ownerTier() : Tier {
+    /**
+     * The identity of the engine that owns this device.
+     *
+     * This property is relevant when a device can only be accessed through
+     * local connection. In that case, the device should store the {@link BaseEngine.ownTier}
+     * property of the engine that configured the device. To ensure that,
+     * the tier must be stored to the persistent state.
+     * This ensures that the device will not be initialized if its configuration
+     * is copied to a different engine, e.g. through a synchronization mechanism.
+     *
+     * If this property is not equal to {@link BaseEngine.ownTier} for the current
+     * engine, the {@link start} and {@link stop} methods will not be called.
+     *
+     * This property defaults to {@link Tier.GLOBAL} which means the device will
+     * be initialized in all engines.
+     */
+    get ownerTier() : string {
         return Tier.GLOBAL;
     }
 

--- a/lib/base_engine.ts
+++ b/lib/base_engine.ts
@@ -56,9 +56,11 @@ export default abstract class BaseEngine {
     }
 
     /**
-     * The current tier of the engine.
+     * The identity of the current engine of the engine.
      *
-     * See {@link BaseDevice.Tier} for an explanation.
+     * This is a string composed of {@link BaseDevice.Tier} and a unique identifier.
+     * It should be accessed and stored by devices that need local connectivity,
+     * to ensure that they are only initialized in the correct engine.
      */
     get ownTier() : string {
         return 'desktop';

--- a/test/test_http_client.js
+++ b/test/test_http_client.js
@@ -192,11 +192,9 @@ async function testGetDeviceList(klass) {
 
     const page0 = await _httpClient.getDeviceList(klass);
 
-    // weird values for page are the same as ignored
+    // negative values for page are the same as ignored
     const pageMinusOne = await _httpClient.getDeviceList(klass, -1);
     assert.deepStrictEqual(pageMinusOne, page0);
-    const pageInvalid = await _httpClient.getDeviceList(klass, 'invalid');
-    assert.deepStrictEqual(pageInvalid, page0);
 
     for (let i = 0; ; i++) {
         const page = await _httpClient.getDeviceList(klass, i, 10);


### PR DESCRIPTION
The tier properties are necessary to support cloud sync of devices
with local connectivity (like Home Assistant)