### PR TITLE
Add "exact"-level confidence for dialogue handlers

### DIFF
--- a/lib/dialogue-handler.ts
+++ b/lib/dialogue-handler.ts
@@ -123,6 +123,13 @@ export enum Priority {
  */
 export enum Confidence {
     /**
+     * The dialogue handler matched this utterance exactly (using some template
+     * or regular expression), and it is a direct command that should take over
+     * from other dialogue handlers.
+     */
+    EXACT_IN_DOMAIN_COMMAND,
+
+    /**
      * The dialogue handler is confident that the utterance is in-domain, and it
      * is a direct command that should take over from other dialogue handlers.
      */
@@ -134,6 +141,14 @@ export enum Confidence {
      * dialogue handlers.
      */
     NONCONFIDENT_IN_DOMAIN_COMMAND,
+
+    /**
+     * The dialogue handler matched this utterance exactly (using some template
+     * or regular expression), and it is a follow-up to the current dialogue handler state.
+     *
+     * The utterance will not be dispatched if the dialogue handler is not current.
+     */
+    EXACT_IN_DOMAIN_FOLLOWUP,
 
     /**
      * The dialogue handler is confident that the utterance is in-domain, and it


### PR DESCRIPTION
Using this, we can match "ask bing" and similar templates exactly
and unconditionally take over from Thingtalk commands, even if
the ThingTalk command is parsed confidently.

Note that the order of enums changed. This has no effect if one
uses the enum name, but is an ABI break otherwise.