### PR TITLE
Fix translation of builtin devices

### DIFF
--- a/lib/downloader.ts
+++ b/lib/downloader.ts
@@ -62,7 +62,7 @@ export default class ModuleDownloader {
     private _client : BaseClient;
     private _schemas : ThingTalk.SchemaRetriever;
     private _builtins : BuiltinRegistry;
-    private _builtinGettextDomain : string|undefined;
+    private _builtinGettext : ((x : string) => string)|undefined;
     private _cacheDir : string;
     private _moduleRequests : Map<string, Promise<Module>>;
 
@@ -70,7 +70,7 @@ export default class ModuleDownloader {
                 client : BaseClient,
                 schemas : ThingTalk.SchemaRetriever,
                 builtins : BuiltinRegistry = {},
-                options : { builtinGettextDomain ?: string } = {}) {
+                options : { builtinGettext ?: (x : string) => string } = {}) {
         this._platform = platform;
         this._client = client;
 
@@ -78,7 +78,7 @@ export default class ModuleDownloader {
         this._schemas = schemas;
 
         this._builtins = builtins;
-        this._builtinGettextDomain = options.builtinGettextDomain;
+        this._builtinGettext = options.builtinGettext;
         this._cacheDir = platform.getCacheDir() + '/device-classes';
         this._moduleRequests = new Map;
 
@@ -196,7 +196,7 @@ export default class ModuleDownloader {
             if (moduleType === 'org.thingpedia.builtin') {
                 if (this._builtins[id]) {
                     return new Modules['org.thingpedia.builtin'](id, classdef, this, this._builtins[id].module,
-                                                                 this._builtinGettextDomain);
+                                                                 this._builtinGettext);
                 } else {
                     return new Modules['org.thingpedia.builtin.unsupported'](id, classdef, this);
                 }

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -42,12 +42,12 @@ export default class DeviceFactory {
      * @param client - the client to use to contact Thingpedia
      * @param builtins - implementation of builtin classes
      * @param options - additional configuration options
-     * @param options.builtinGettextDomain - gettext domain to use to translate builtin devices
+     * @param options.builtinGettext - gettext function to use to translate builtin devices
      */
     constructor(engine : BaseEngine,
                 client : BaseClient,
                 builtins : Record<string, { class : string, module : BaseDevice.DeviceClass<BaseDevice> }> = {},
-                options : { builtinGettextDomain ?: string } = {}) {
+                options : { builtinGettext ?: (x : string) => string } = {}) {
         this._engine = engine;
         this._downloader = new ModuleDownloader(engine.platform, client, engine.schemas, builtins, options);
     }

--- a/test/test_i18n.js
+++ b/test/test_i18n.js
@@ -46,9 +46,10 @@ async function testBuiltin() {
     const platform = new MockPlatform('it-IT');
     const engine = new MockEngine(platform);
     const tpClient = platform.getCapability('thingpedia-client');
+    const gettext = platform.getCapability('gettext');
 
     const downloader = new ModuleDownloader(platform, tpClient, engine.schemas, Builtins, {
-        builtinGettextDomain: 'thingengine-core'
+        builtinGettext: (x) => gettext.dgettext('thingengine-core', x)
     });
     const module = await downloader.getModule('org.thingpedia.builtin.translatable');
 


### PR DESCRIPTION
We need to pass a callback instead of just the domain name because
translations won't be found in the platform gettext object