### PR TITLE
Add file-based parameter dataset sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/
 test/snapshot.tt
 testprefs.json
 test.json
+*.sqlite

--- a/lib/file_parameter_provider.ts
+++ b/lib/file_parameter_provider.ts
@@ -18,19 +18,52 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
-
-import * as util from 'util';
+import * as sqlite3 from 'sqlite3';
 import * as fs from 'fs';
+import { promises as pfs } from 'fs';
 import byline from 'byline';
 import csvparse from 'csv-parse';
 import * as path from 'path';
+import * as Stream from 'stream';
+import JSONStream from 'JSONStream';
 
 import BaseClient from './base_client';
 
-interface ParameterRecord {
-    preprocessed : string;
-    value : string;
-    weight : number;
+const SQLITE_SCHEMA_VERSION = 1;
+const SQLITE_SCHEMA = `
+create table entity (
+    locale text not null,
+    type text not null,
+    value text not null,
+    name text not null,
+    canonical text not null,
+    serial integer not null
+);
+create index entity_type on entity(locale, type, serial);
+create index entity_canonical on entity(locale, type, canonical);
+
+create table string (
+    locale text not null,
+    type text not null,
+    value text not null,
+    preprocessed text not null,
+    serial integer not null,
+    weight real not null default 1.0,
+    weight_cumsum real not null
+);
+create index string_type on string(locale, type, serial);
+create index string_sample on string(locale, type, weight_cumsum);
+`;
+
+async function dbAll(db : sqlite3.Database, query : string, ...args : unknown[]) {
+    return new Promise<any[]>((resolve, reject) => {
+        db.all(query, ...args, (err : Error|null, rows : any[]) => {
+            if (err)
+                reject(err);
+            else
+                resolve(rows);
+        });
+    });
 }
 
 /**
@@ -42,11 +75,12 @@ interface ParameterRecord {
  * Entities are loaded from the JSON files returned from
  * https://almond.stanford.edu/thingpedia/api/v3/entities/list/:x
  */
-export default class FileParameterProvider {
+class FileParameterProvider {
     private _filename : string;
     private _paramLocale : string;
     private _dirname : string;
     private _paths : Map<string, string>;
+    private _db ! : sqlite3.Database;
 
     constructor(filename : string, paramLocale : string) {
         this._filename = filename;
@@ -56,6 +90,11 @@ export default class FileParameterProvider {
     }
 
     async load() : Promise<void> {
+        await this._loadPaths();
+        this._db = await this._loadOrCreateSqliteCache();
+    }
+
+    private async _loadPaths() {
         const file = fs.createReadStream(this._filename);
         file.setEncoding('utf8');
 
@@ -68,8 +107,7 @@ export default class FileParameterProvider {
             const [stringOrEntity, locale, type, filepath] = line.trim().split('\t');
             if (stringOrEntity !== 'string' && stringOrEntity !== 'entity')
                 throw new Error(`Invalid syntax: ${line}`);
-            if (locale === this._paramLocale)
-                this._paths.set(stringOrEntity + '+' + type, path.resolve(this._dirname, filepath));
+            this._paths.set(stringOrEntity + '+' + locale + '+' + type, path.resolve(this._dirname, filepath));
         });
 
         await new Promise((resolve, reject) => {
@@ -78,69 +116,129 @@ export default class FileParameterProvider {
         });
     }
 
-    private async _getStrings(stringType : string) : Promise<ParameterRecord[]> {
-        const filepath = this._paths.get('string+' + stringType);
+    private async _loadOrCreateSqliteCache() {
+        const sqlitefilename = this._filename.replace(/\.tsv$/, '') + `.${SQLITE_SCHEMA_VERSION}.sqlite`;
+
+        let mtime = -1, exists = false;
+        try {
+            const stat = await pfs.stat(sqlitefilename);
+            mtime = stat.mtimeMs;
+            exists = true;
+        } catch(e) {
+            if (e.code !== 'ENOENT')
+                throw e;
+        }
+
+        const db = new sqlite3.Database(sqlitefilename, sqlite3.OPEN_CREATE|sqlite3.OPEN_READWRITE);
+        db.serialize();
+        if (!exists) {
+            db.run(`PRAGMA journal_mode=WAL`);
+            db.exec(SQLITE_SCHEMA);
+        }
+
+        for (const [typekey, filename] of this._paths) {
+            const [stringOrEntity, locale, type] = typekey.split('+', 3);
+
+            const stat = await pfs.stat(filename);
+            if (stat.mtimeMs <= mtime)
+                continue;
+
+            console.log(`${stringOrEntity} ${type} (${locale}) is newer than sqlite db, updating`);
+
+            db.run(`delete from ${stringOrEntity} where locale = ? and type = ?`, locale, type);
+            if (stringOrEntity === 'string')
+                await this._loadStrings(type, locale, db);
+            else
+                await this._loadEntities(type, locale, db);
+        }
+
+        db.parallelize();
+        return db;
+    }
+
+    private async _loadStrings(stringType : string, locale : string, db : sqlite3.Database) {
+        const filepath = this._paths.get(`string+${locale}+${stringType}`);
         if (!filepath)
-            return [];
+            return;
 
-        const strings : ParameterRecord[] = [];
-        const input = fs.createReadStream(filepath)
-            .pipe(csvparse({ delimiter: '\t', relax: true }));
+        let serial = 0;
+        let weight_cumsum = 0;
+        const stmt = db.prepare(`insert into string(locale, type, value, preprocessed, serial, weight, weight_cumsum) values(?,?,?,?,?,?,?)`);
+        const stream = fs.createReadStream(filepath)
+            .pipe(csvparse({ delimiter: '\t', relax: true, relaxColumnCount: true }))
+            .pipe(new Stream.Writable({
+                objectMode: true,
 
-        input.on('data', (line) => {
-            const value = line[0];
-            let preprocessed, weight;
-            if (line.length === 1) {
-                preprocessed = line[0];
-                weight = 1.0;
-            } else if (line.length === 2) {
-                if (isFinite(+line[1])) {
-                    preprocessed = line[0];
-                    weight = line[1];
-                } else {
-                    preprocessed = line[1];
-                    weight = 1.0;
+                write(line, encoding, callback) {
+                    const value = line[0];
+                    let preprocessed : string, weight : number;
+                    if (line.length === 1) {
+                        preprocessed = line[0];
+                        weight = 1.0;
+                    } else if (line.length === 2) {
+                        if (isFinite(+line[1])) {
+                            preprocessed = line[0];
+                            weight = parseFloat(line[1]);
+                        } else {
+                            preprocessed = line[1];
+                            weight = 1.0;
+                        }
+                    } else {
+                        preprocessed = line[1];
+                        weight = parseFloat(line[2]) || 1.0;
+                    }
+                    if (!(weight > 0.0))
+                        weight = 1.0;
+
+                    weight_cumsum += weight;
+                    stmt.run([locale, stringType, value, preprocessed, serial++, weight, weight_cumsum], callback);
                 }
-            } else {
-                preprocessed = line[1];
-                weight = parseFloat(line[2]) || 1.0;
-            }
-            if (!(weight > 0.0))
-                weight = 1.0;
+            }));
 
-            strings.push({ value, preprocessed, weight });
-        });
-
-        return new Promise<ParameterRecord[]>((resolve, reject) => {
-            input.on('end', () => {
-                if (strings.length === 0)
-                    console.log('actually no values for', stringType, filepath);
-                resolve(strings);
-            });
-            input.on('error', reject);
+        await new Promise((resolve, reject) => {
+            stream.on('finish', resolve);
+            stream.on('error', reject);
         });
     }
 
-    private async _getEntities(stringType : string) : Promise<ParameterRecord[]> {
-        return (await this.getEntity(stringType)).map((e) => {
-            return { preprocessed: e.canonical, weight: 1.0, value:e.value, name:e.name };
-        });
-    }
-
-    async getEntity(stringType : string) : Promise<BaseClient.EntityRecord[]> {
-        const filepath = this._paths.get('entity+' + stringType);
+    private async _loadEntities(entityType : string, locale : string, db : sqlite3.Database) {
+        const filepath = this._paths.get(`entity+${locale}+${entityType}`);
         if (!filepath)
-            return [];
+            return;
 
-        const data : BaseClient.EntityRecord[] = JSON.parse(await util.promisify(fs.readFile)(filepath, { encoding: 'utf8' })).data;
-        data.forEach((r) => {
-            if (!r.type)
-                r.type = stringType;
+        let serial = 0;
+        const stmt = db.prepare(`insert into entity(locale, type, value, name, canonical, serial) values(?,?,?,?,?,?)`);
+        const stream = fs.createReadStream(filepath)
+            .pipe(JSONStream.parse('data.*'))
+            .pipe(new Stream.Writable({
+                objectMode: true,
+
+                write(obj : BaseClient.EntityRecord, encoding, callback) {
+                    stmt.run([locale, obj.type || entityType, obj.value, obj.name, obj.canonical, serial++], callback);
+                }
+            }));
+
+        await new Promise((resolve, reject) => {
+            stream.on('finish', resolve);
+            stream.on('error', reject);
         });
-        return data;
     }
 
-    async get(valueListType : 'string'|'entity', valueListName : string) : Promise<ParameterRecord[]> {
+    private async _getStrings(stringType : string) : Promise<FileParameterProvider.ParameterRecord[]> {
+        return dbAll(this._db, `select value,preprocessed,weight from string where locale = ? and type = ? order by serial asc`, [this._paramLocale, stringType]);
+    }
+
+    private async _getEntities(stringType : string) : Promise<FileParameterProvider.ParameterRecord[]> {
+        return dbAll(this._db, `select canonical as preprocessed, 1.0 as weight, value
+            from entity where locale = ? and type = ? order by serial asc`, [this._paramLocale, stringType]);
+    }
+
+    async lookupEntity(stringType : string, term : string) : Promise<BaseClient.EntityRecord[]> {
+        return dbAll(this._db, `select type,name,value,canonical from entity where locale = ? and type = ?
+            and (value = ? or canonical like ?)`, [this._paramLocale, stringType, term, '%' + (term.toLowerCase()) + '%']);
+    }
+
+    async get(valueListType : 'string'|'entity', valueListName : string) : Promise<FileParameterProvider.ParameterRecord[]> {
         switch (valueListType) {
         case 'string':
             return this._getStrings(valueListName);
@@ -151,3 +249,12 @@ export default class FileParameterProvider {
         }
     }
 }
+namespace FileParameterProvider {
+    export interface ParameterRecord {
+        preprocessed : string;
+        value : string;
+        weight : number;
+    }
+}
+
+export default FileParameterProvider;

--- a/lib/file_parameter_provider.ts
+++ b/lib/file_parameter_provider.ts
@@ -1,0 +1,153 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Thingpedia
+//
+// Copyright 2019-2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+
+import * as util from 'util';
+import * as fs from 'fs';
+import byline from 'byline';
+import csvparse from 'csv-parse';
+import * as path from 'path';
+
+import BaseClient from './base_client';
+
+interface ParameterRecord {
+    preprocessed : string;
+    value : string;
+    weight : number;
+}
+
+/**
+ * Load strings and entities from files.
+ *
+ * Strings are loaded from the TSV files generated from
+ * https://almond.stanford.edu/thingpedia/strings/download/:x
+ *
+ * Entities are loaded from the JSON files returned from
+ * https://almond.stanford.edu/thingpedia/api/v3/entities/list/:x
+ */
+export default class FileParameterProvider {
+    private _filename : string;
+    private _paramLocale : string;
+    private _dirname : string;
+    private _paths : Map<string, string>;
+
+    constructor(filename : string, paramLocale : string) {
+        this._filename = filename;
+        this._paramLocale = paramLocale || 'en-US';
+        this._dirname = path.dirname(filename);
+        this._paths = new Map;
+    }
+
+    async load() : Promise<void> {
+        const file = fs.createReadStream(this._filename);
+        file.setEncoding('utf8');
+
+        const input = byline(file);
+
+        input.on('data', (line) => {
+            if (/^\s*(#|$)/.test(line))
+                return;
+
+            const [stringOrEntity, locale, type, filepath] = line.trim().split('\t');
+            if (stringOrEntity !== 'string' && stringOrEntity !== 'entity')
+                throw new Error(`Invalid syntax: ${line}`);
+            if (locale === this._paramLocale)
+                this._paths.set(stringOrEntity + '+' + type, path.resolve(this._dirname, filepath));
+        });
+
+        await new Promise((resolve, reject) => {
+            input.on('end', resolve);
+            input.on('error', reject);
+        });
+    }
+
+    private async _getStrings(stringType : string) : Promise<ParameterRecord[]> {
+        const filepath = this._paths.get('string+' + stringType);
+        if (!filepath)
+            return [];
+
+        const strings : ParameterRecord[] = [];
+        const input = fs.createReadStream(filepath)
+            .pipe(csvparse({ delimiter: '\t', relax: true }));
+
+        input.on('data', (line) => {
+            const value = line[0];
+            let preprocessed, weight;
+            if (line.length === 1) {
+                preprocessed = line[0];
+                weight = 1.0;
+            } else if (line.length === 2) {
+                if (isFinite(+line[1])) {
+                    preprocessed = line[0];
+                    weight = line[1];
+                } else {
+                    preprocessed = line[1];
+                    weight = 1.0;
+                }
+            } else {
+                preprocessed = line[1];
+                weight = parseFloat(line[2]) || 1.0;
+            }
+            if (!(weight > 0.0))
+                weight = 1.0;
+
+            strings.push({ value, preprocessed, weight });
+        });
+
+        return new Promise<ParameterRecord[]>((resolve, reject) => {
+            input.on('end', () => {
+                if (strings.length === 0)
+                    console.log('actually no values for', stringType, filepath);
+                resolve(strings);
+            });
+            input.on('error', reject);
+        });
+    }
+
+    private async _getEntities(stringType : string) : Promise<ParameterRecord[]> {
+        return (await this.getEntity(stringType)).map((e) => {
+            return { preprocessed: e.canonical, weight: 1.0, value:e.value, name:e.name };
+        });
+    }
+
+    async getEntity(stringType : string) : Promise<BaseClient.EntityRecord[]> {
+        const filepath = this._paths.get('entity+' + stringType);
+        if (!filepath)
+            return [];
+
+        const data : BaseClient.EntityRecord[] = JSON.parse(await util.promisify(fs.readFile)(filepath, { encoding: 'utf8' })).data;
+        data.forEach((r) => {
+            if (!r.type)
+                r.type = stringType;
+        });
+        return data;
+    }
+
+    async get(valueListType : 'string'|'entity', valueListName : string) : Promise<ParameterRecord[]> {
+        switch (valueListType) {
+        case 'string':
+            return this._getStrings(valueListName);
+        case 'entity':
+            return this._getEntities(valueListName);
+        default:
+            throw new TypeError(`Unexpected value list type ${valueListType}`);
+        }
+    }
+}

--- a/lib/http_client.ts
+++ b/lib/http_client.ts
@@ -32,6 +32,7 @@ import * as Helpers from './helpers';
 import BaseClient from './base_client';
 import BasePlatform from './base_platform';
 import { makeDeviceFactory } from './device_factory_utils';
+import FileParameterProvider from './file_parameter_provider';
 
 const DEFAULT_THINGPEDIA_URL = 'https://thingpedia.stanford.edu/thingpedia';
 
@@ -56,6 +57,8 @@ interface APIQueryParams {
 export default class HttpClient extends BaseClient {
     platform : BasePlatform;
     private _url : string;
+    private _cachedEntities : Map<string, BaseClient.EntityRecord[]>;
+    private _localEntityProvider : Promise<FileParameterProvider|null>|null;
 
     /**
      * Construct a new HttpClient.
@@ -67,6 +70,8 @@ export default class HttpClient extends BaseClient {
         super();
         this.platform = platform;
         this._url = url + '/api/v3';
+        this._localEntityProvider = null;
+        this._cachedEntities = new Map;
     }
 
     /**
@@ -492,9 +497,66 @@ export default class HttpClient extends BaseClient {
             { method: 'POST' });
     }
 
-    lookupEntity(entityType : string, searchTerm : string) : Promise<BaseClient.EntityLookupResult> {
-        return this._simpleRequest('/entities/lookup/' + encodeURIComponent(entityType),
-            { q: searchTerm }, 'application/json', { extractData: false });
+    private _getLocalEntityProvider() {
+        if (this._localEntityProvider)
+            return this._localEntityProvider;
+        return this._localEntityProvider = this._doGetLocalEntityProvider();
+    }
+
+    private async _getParameterDatasetsFile() {
+        const developerDirs = this._getDeveloperDirs();
+
+        if (!developerDirs)
+            return null;
+
+        // for each developer directory, search in the same directory
+        // and in the parent directory
+        // this covers the normal case where it's in the same directory,
+        // and the thingpedia-common-devices case
+        for (const d of developerDirs) {
+            let localPath = path.resolve(d, 'parameter-datasets.tsv');
+            if (await util.promisify(fs.exists)(localPath))
+                return localPath;
+            localPath = path.resolve(d, '../parameter-datasets.tsv');
+            if (await util.promisify(fs.exists)(localPath))
+                return localPath;
+        }
+
+        return null;
+    }
+
+    private async _doGetLocalEntityProvider() {
+        const filename = await this._getParameterDatasetsFile();
+        if (!filename)
+            return null;
+        const provider = new FileParameterProvider(filename, this.platform.locale);
+        await provider.load();
+        return provider;
+    }
+
+    async lookupEntity(entityType : string, searchTerm : string) : Promise<BaseClient.EntityLookupResult> {
+        const cached = this._cachedEntities.get(entityType);
+        if (cached)
+            return { data: cached, meta: { name: entityType, is_well_known: false, has_ner_support: true } };
+
+        const localProvider = await this._getLocalEntityProvider();
+        if (localProvider) {
+            // ignore search term, return everything
+            const result = await localProvider.getEntity(entityType);
+            if (result.length > 0) {
+                this._cachedEntities.set(entityType, result);
+                return { data: result, meta: { name: entityType, is_well_known: false, has_ner_support: true } };
+            }
+        }
+
+        try {
+            return await this._simpleRequest('/entities/lookup/' + encodeURIComponent(entityType),
+                { q: searchTerm }, 'application/json', { extractData: false });
+        } catch(e) {
+            if (e.code !== 404)
+                throw e;
+            return { data: [], meta: { name: entityType, is_well_known: false, has_ner_support: false } };
+        }
     }
 
     lookupLocation(searchTerm : string, around ?: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,6 +31,7 @@ import DialogueHandler from './dialogue-handler';
 import * as FormatObjects from './format_objects';
 
 import * as ThingTalk from 'thingtalk';
+import FileParameterProvider from './file_parameter_provider';
 
 /**
  * Versioning information for the library.
@@ -143,6 +144,7 @@ export {
     FileClient,
     DeviceFactory,
     DeviceConfigUtils,
+    FileParameterProvider,
 
     // expose errors
     ImplementationError,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,6 +3216,12 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,6 +1053,11 @@
         "which": "^2.0.1"
       }
     },
+    "csv-parse": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,6 +470,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/JSONStream": {
+      "version": "npm:@types/jsonstream@0.8.30",
+      "resolved": "https://registry.npmjs.org/@types/jsonstream/-/jsonstream-0.8.30.tgz",
+      "integrity": "sha512-KqHs2eAapKL7ZKUiKI/giUYPVgkoDXkVGFehk3goo+3Q8qwxVVRC3iwg+hK/THORbcri4RRxTtlm3JoSY1KZLQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/byline": {
       "version": "4.2.33",
       "resolved": "https://registry.npmjs.org/@types/byline/-/byline-4.2.33.tgz",
@@ -538,6 +547,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
       "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
+    },
+    "@types/sqlite3": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sqlite3/-/sqlite3-3.1.7.tgz",
+      "integrity": "sha512-8FHV/8Uzd7IwdHm5mvmF2Aif4aC/gjrt4axWD9SmfaxITnOjtOhCbOSTuqv/VbH1uq0QrwlaTj9aTz3gmR6u4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/tmp": {
       "version": "0.2.2",
@@ -636,6 +654,20 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -673,7 +705,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -690,8 +721,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -711,11 +741,25 @@
         "default-require-extensions": "^3.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
     },
     "arg": {
       "version": "4.1.3",
@@ -747,7 +791,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -755,8 +798,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -767,20 +809,17 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -791,7 +830,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -801,6 +839,15 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
       "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
       "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "optional": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -886,8 +933,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "4.1.2",
@@ -940,6 +986,11 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -956,6 +1007,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -982,7 +1038,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -997,6 +1052,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "consumer-queue": {
       "version": "1.1.0",
@@ -1062,7 +1122,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1081,6 +1140,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1109,8 +1173,17 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "4.0.2",
@@ -1140,7 +1213,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1155,8 +1227,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding": {
       "version": "0.1.13",
@@ -1404,20 +1475,17 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -1435,8 +1503,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1537,14 +1604,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1557,10 +1622,41 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1572,6 +1668,54 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -1615,7 +1759,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1696,20 +1839,17 @@
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "dev": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -1749,6 +1889,11 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -1777,7 +1922,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1797,6 +1941,14 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -1833,6 +1985,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -1893,8 +2050,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -1969,8 +2125,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-weakref": {
       "version": "1.0.1",
@@ -1995,14 +2150,12 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -2130,8 +2283,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -2142,14 +2294,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2160,8 +2310,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -2178,11 +2327,15 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2328,14 +2481,12 @@
     "mime-db": {
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-      "dev": true
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "mime-types": {
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.49.0"
       }
@@ -2351,8 +2502,39 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "mri": {
       "version": "1.1.6",
@@ -2362,14 +2544,46 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node-gettext": {
       "version": "3.0.0",
@@ -2378,6 +2592,117 @@
       "dev": true,
       "requires": {
         "lodash.get": "^4.4.2"
+      }
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "optional": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "optional": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "tar": {
+          "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+          "requires": {
+            "chownr": "^1.1.4",
+            "fs-minipass": "^1.2.7",
+            "minipass": "^2.9.0",
+            "minizlib": "^1.3.3",
+            "mkdirp": "^0.5.5",
+            "safe-buffer": "^5.2.1",
+            "yallist": "^3.1.1"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
       }
     },
     "node-preload": {
@@ -2394,6 +2719,54 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "optional": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "15.1.0",
@@ -2441,8 +2814,12 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -2513,6 +2890,25 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-limit": {
@@ -2601,8 +2997,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -2648,14 +3043,12 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.10.1",
@@ -2670,6 +3063,24 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
+      }
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -2704,7 +3115,6 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2731,14 +3141,12 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -2820,8 +3228,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -2862,8 +3269,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "slash": {
       "version": "3.0.0",
@@ -2961,11 +3367,20 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sqlite3": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
+      "integrity": "sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==",
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp": "3.x",
+        "node-pre-gyp": "^0.11.0"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2990,7 +3405,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3029,7 +3443,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -3089,6 +3502,17 @@
         }
       }
     },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "optional": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -3125,6 +3549,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/thingtalk-units/-/thingtalk-units-0.2.1.tgz",
       "integrity": "sha512-5r7V3m1aqGOJwMEVx41udgIXLNrYJySygQIttUAlwtadArNGRt+5y3ERWCmr/kMF1Rde9h36Ps866vTRxQ7fzA=="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.2.1",
@@ -3207,7 +3636,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3215,8 +3643,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -3299,7 +3726,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3312,8 +3738,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -3325,7 +3750,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -3335,8 +3759,7 @@
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         }
       }
     },
@@ -3373,6 +3796,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node-gettext": "^3.0.2",
     "@types/qs": "^6.9.7",
     "@types/xml2js": "^0.4.9",
+    "JSONStream": "^1.3.5",
     "byline": "^5.0.0",
     "csv-parse": "^4.16.3",
     "feedparser": "^2.2.9",
@@ -27,6 +28,7 @@
     "ip": "^1.1.0",
     "qs": "^6.9.6",
     "smtlib": "^1.0.0",
+    "sqlite3": "^5.0.2",
     "string-interp": "^0.3.5",
     "tmp": "^0.2.1",
     "xml2js": "^0.4.17"
@@ -43,8 +45,10 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@types/JSONStream": "npm:@types/jsonstream@^0.8.30",
     "@types/byline": "^4.2.33",
     "@types/gettext-parser": "^4.0.1",
+    "@types/sqlite3": "^3.1.7",
     "@types/tmp": "^0.2.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node-gettext": "^3.0.0",
     "nyc": "^15.0.0",
     "pegjs": "^0.10.0",
+    "seedrandom": "^3.0.5",
     "source-map-support": "^0.5.20",
     "thingtalk": "^2.1.0-alpha.9",
     "tough-cookie": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/qs": "^6.9.7",
     "@types/xml2js": "^0.4.9",
     "byline": "^5.0.0",
+    "csv-parse": "^4.16.3",
     "feedparser": "^2.2.9",
     "gettext-parser": "^4.0.2",
     "ip": "^1.1.0",

--- a/test/developer-dir/parameter-datasets.tsv
+++ b/test/developer-dir/parameter-datasets.tsv
@@ -1,1 +1,3 @@
 entity	en-US	com.example:my_entity	parameter-datasets/com.example:my_entity.json
+string	en-US	com.example:my_string	parameter-datasets/com.example:my_string.tsv
+string	en-US	com.example:my_string2	parameter-datasets/com.example:my_string2.tsv

--- a/test/developer-dir/parameter-datasets.tsv
+++ b/test/developer-dir/parameter-datasets.tsv
@@ -1,0 +1,1 @@
+entity	en-US	com.example:my_entity	parameter-datasets/com.example:my_entity.json

--- a/test/developer-dir/parameter-datasets/com.example:my_entity.json
+++ b/test/developer-dir/parameter-datasets/com.example:my_entity.json
@@ -1,0 +1,15 @@
+{
+    "result": "ok",
+    "data": [
+        {
+            "name": "Entity Alice",
+            "value": "1",
+            "canonical": "entity alice"
+        },
+        {
+            "name": "Entity Bob",
+            "value": "2",
+            "canonical": "entity bob"
+        }
+    ]
+}

--- a/test/developer-dir/parameter-datasets/com.example:my_string.tsv
+++ b/test/developer-dir/parameter-datasets/com.example:my_string.tsv
@@ -1,0 +1,4 @@
+Aaaa	aaaa	1.0
+bbbb	5.0
+CCcc	cccc
+DDDD	dddd	1.0

--- a/test/developer-dir/parameter-datasets/com.example:my_string2.tsv
+++ b/test/developer-dir/parameter-datasets/com.example:my_string2.tsv
@@ -1,0 +1,3 @@
+xxxx
+yyyy
+zzzz

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@
 import '../lib/index';
 
 process.on('unhandledRejection', (up) => {
-    throw up; 
+    throw up;
 });
 process.env.TEST_MODE = '1';
 
@@ -48,6 +48,7 @@ seq([
     ('./test_refcounted'),
     ('./test_content'),
     ('./test_factory_api'),
+    ('./test_parameter_provider'),
     ('./test_http_client'),
     ('./test_file_client'),
     ('./test_builtin'),

--- a/test/test_file_client.js
+++ b/test/test_file_client.js
@@ -34,6 +34,7 @@ const _fileClient = new FileClient({
     thingpedia: path.resolve(path.dirname(module.filename), './data/thingpedia.tt'),
     entities: path.resolve(path.dirname(module.filename), './data/entities.json'),
     dataset: path.resolve(path.dirname(module.filename), './data/dataset.tt'),
+    parameter_datasets: path.resolve(path.dirname(module.filename), './developer-dir/parameter-datasets.tsv'),
 });
 const _schemaRetriever = new ThingTalk.SchemaRetriever(_fileClient, null, true);
 
@@ -199,6 +200,32 @@ async function testSearchDevices() {
     }]);
 }
 
+async function testLookupEntity() {
+    const entity = await _fileClient.lookupEntity('com.example:my_entity', 'alice');
+
+    assert.deepStrictEqual(entity, {
+        data: [
+            {
+                name: "Entity Alice",
+                value: "1",
+                canonical: "entity alice",
+                type: 'com.example:my_entity'
+            },
+            {
+                name: "Entity Bob",
+                value: "2",
+                canonical: "entity bob",
+                type: 'com.example:my_entity'
+            }
+        ],
+        meta: {
+            has_ner_support: true,
+            is_well_known: false,
+            name: 'com.example:my_entity'
+        }
+    });
+}
+
 async function main() {
     await testGetDeviceCode();
     await testGetSchemas(false);
@@ -209,6 +236,8 @@ async function main() {
 
     await testGetDeviceList();
     await testSearchDevices();
+
+    await testLookupEntity();
 }
 
 export default main;

--- a/test/test_file_client.js
+++ b/test/test_file_client.js
@@ -210,12 +210,6 @@ async function testLookupEntity() {
                 value: "1",
                 canonical: "entity alice",
                 type: 'com.example:my_entity'
-            },
-            {
-                name: "Entity Bob",
-                value: "2",
-                canonical: "entity bob",
-                type: 'com.example:my_entity'
             }
         ],
         meta: {

--- a/test/test_http_client.js
+++ b/test/test_http_client.js
@@ -483,12 +483,6 @@ async function testLookupEntity() {
                 value: "1",
                 canonical: "entity alice",
                 type: 'com.example:my_entity'
-            },
-            {
-                name: "Entity Bob",
-                value: "2",
-                canonical: "entity bob",
-                type: 'com.example:my_entity'
             }
         ],
         meta: {

--- a/test/test_http_client.js
+++ b/test/test_http_client.js
@@ -472,6 +472,52 @@ async function testGetExamples() {
     }
 }
 
+
+async function testLookupEntity() {
+    const entity = await _localDeveloperHttpClient.lookupEntity('com.example:my_entity', 'alice');
+
+    assert.deepStrictEqual(entity, {
+        data: [
+            {
+                name: "Entity Alice",
+                value: "1",
+                canonical: "entity alice",
+                type: 'com.example:my_entity'
+            },
+            {
+                name: "Entity Bob",
+                value: "2",
+                canonical: "entity bob",
+                type: 'com.example:my_entity'
+            }
+        ],
+        meta: {
+            has_ner_support: true,
+            is_well_known: false,
+            name: 'com.example:my_entity'
+        }
+    });
+
+    const entity2 = await _localDeveloperHttpClient.lookupEntity('com.yelp:restaurant_cuisine', 'italian');
+
+    assert.deepStrictEqual(entity2, {
+        data: [
+            {
+                name: "Italian",
+                value: "italian",
+                canonical: "italian",
+                type: 'com.yelp:restaurant_cuisine'
+            }
+        ],
+        meta: {
+            has_ner_support: 1,
+            is_well_known: 0,
+            name: 'Cuisines in Yelp'
+        },
+        result: 'ok'
+    });
+}
+
 async function testLookupLocation() {
     const data = await _httpClient.lookupLocation('seattle');
     console.log(data);
@@ -619,6 +665,7 @@ async function main() {
     await testGetExamples();
 
     await testLookupLocation();
+    await testLookupEntity();
 
     await testGetEntities();
 

--- a/test/test_parameter_provider.js
+++ b/test/test_parameter_provider.js
@@ -1,0 +1,73 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Thingpedia
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import assert from 'assert';
+import * as path from 'path';
+
+import FileParameterProvider from "../lib/file_parameter_provider";
+
+const provider = new FileParameterProvider(path.resolve(path.dirname(module.filename), './developer-dir/parameter-datasets.tsv'), 'en-US');
+
+async function testBasic() {
+    assert.deepStrictEqual(await provider.get('entity', 'com.example:my_entity'), [
+        {
+            preprocessed: 'entity alice',
+            value: '1',
+            weight: 1.0
+        },
+        {
+            preprocessed: 'entity bob',
+            value: '2',
+            weight: 1.0
+        }
+    ]);
+
+    assert.deepStrictEqual(await provider.get('string', 'com.example:my_string'), [
+        {
+            preprocessed: 'aaaa',
+            value: 'Aaaa',
+            weight: 1.0
+        },
+        {
+            preprocessed: 'bbbb',
+            value: 'bbbb',
+            weight: 5.0
+        },
+        {
+            preprocessed: 'cccc',
+            value: 'CCcc',
+            weight: 1.0
+        },
+        {
+            preprocessed: 'dddd',
+            value: 'DDDD',
+            weight: 1.0
+        }
+    ]);
+}
+
+async function main() {
+    await provider.load();
+
+    await testBasic();
+}
+export default main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
This PR solves a long-standing missing feature with the developer directory support, namely looking up entities from the local directory instead of Thingpedia. It does so by using the parameter datasets, which already contain all the relevant entities in the right format.

While we're here, I'm also introducing a sqlite cache for the parameter datasets, which allows to lookup entities without loading the entire file in memory, and also allows memory-efficient sampling for augmentation.