### PR TITLE
Always override existing symlinks to thingpedia, thingtalk

### DIFF
--- a/lib/downloader.ts
+++ b/lib/downloader.ts
@@ -41,6 +41,12 @@ function safeMkdir(dir : string) {
 
 function safeSymlinkSync(from : string, to : string) {
     try {
+        fs.unlinkSync(to);
+    } catch(e : any) {
+        if (e.code !== 'ENOENT')
+            throw e;
+    }
+    try {
         fs.symlinkSync(from, to, 'dir');
     } catch(e : any) {
         if (e.code !== 'EEXIST')


### PR DESCRIPTION
This is necessary to handle upgrades correctly, as the location
of the thingpedia and thingtalk module might have changed.